### PR TITLE
fix build for msvc 2013

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ include_directories(${UNBOUND_INCLUDE})
 
 if(MSVC)
   add_definitions("/bigobj /MP /W3 /GS- /D_CRT_SECURE_NO_WARNINGS /wd4996 /wd4345 /D_WIN32_WINNT=0x0600 /DWIN32_LEAN_AND_MEAN /DGTEST_HAS_TR1_TUPLE=0 /FIinline_c.h /D__SSE4_1__")
+  add_definitions("/DMINIUPNP_STATICLIB")
   # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Dinline=__inline")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:10485760")
   if(STATIC)

--- a/cmake/FindUnbound.cmake
+++ b/cmake/FindUnbound.cmake
@@ -27,14 +27,24 @@
 
 MESSAGE(STATUS "Looking for libunbound")
 
-FIND_PATH(UNBOUND_INCLUDE_DIR
-  NAMES unbound.h
-  PATH_SUFFIXES include/ include/unbound/
-  PATHS "${PROJECT_SOURCE_DIR}"
-  ${UNBOUND_ROOT}
-  $ENV{UNBOUND_ROOT}
-  /usr/local/
-  /usr/
-)
+if(MSVC)
+  # MSVC build: check for pre-compiled library at most probable location
+  set(UNBOUND_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/external/unbound/libunbound)
+  set(UNBOUND_LIBRARIES ${PROJECT_SOURCE_DIR}/external/unbound/.libs/libunbound.dll.a)
+  if(NOT EXISTS ${UNBOUND_LIBRARIES})
+    message(FATAL_ERROR "libunbound library not found") 
+  endif()
 
-find_library(UNBOUND_LIBRARIES unbound)
+else()
+  FIND_PATH(UNBOUND_INCLUDE_DIR
+    NAMES unbound.h
+    PATH_SUFFIXES include/ include/unbound/
+    PATHS "${PROJECT_SOURCE_DIR}"
+    ${UNBOUND_ROOT}
+    $ENV{UNBOUND_ROOT}
+    /usr/local/
+    /usr/
+  )
+
+  find_library(UNBOUND_LIBRARIES unbound)
+endif()

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -112,13 +112,6 @@ namespace nodetool
     size_t get_outgoing_connections_count();
     peerlist_manager& get_peerlist_manager(){return m_peerlist;}
   private:
-    const std::vector<std::string> m_seed_nodes_list =
-    { "seeds.moneroseeds.se"
-    , "seeds.moneroseeds.ae.org"
-    , "seeds.moneroseeds.ch"
-    , "seeds.moneroseeds.li"
-    };
-
     typedef COMMAND_REQUEST_STAT_INFO_T<typename t_payload_net_handler::stat_info> COMMAND_REQUEST_STAT_INFO;
 
     CHAIN_LEVIN_INVOKE_MAP2(p2p_connection_context); //move levin_commands_handler interface invoke(...) callbacks into invoke map

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -240,6 +240,13 @@ namespace nodetool
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::init(const boost::program_options::variables_map& vm, bool testnet)
   {
+    const std::vector<std::string> m_seed_nodes_list =
+    { "seeds.moneroseeds.se"
+    , "seeds.moneroseeds.ae.org"
+    , "seeds.moneroseeds.ch"
+    , "seeds.moneroseeds.li"
+    };
+
     if (testnet)
     {
       append_net_address(m_seed_nodes, "107.152.187.202:28080");

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -5,6 +5,13 @@
 # ctest.  You can select which tests to run using 'ctest -R regex'.
 # For more options, run 'ctest --help'.
 
+# Modification for Monero/MSVC: force gtest.lib to use static/dynamic settings from root
+if(MSVC)
+  if(NOT STATIC)
+    set(BUILD_SHARED_LIBS ON)
+  endif()
+endif()
+
 # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to
 # make it prominent in the GUI.
 option(BUILD_SHARED_LIBS "Build shared libraries (DLLs)." OFF)

--- a/tests/gtest/include/gtest/internal/gtest-port.h
+++ b/tests/gtest/include/gtest/internal/gtest-port.h
@@ -188,7 +188,9 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
+#if !defined(_MSC_VER)
+# include <unistd.h>
+#endif
 #ifndef _WIN32_WCE
 # include <sys/types.h>
 # include <sys/stat.h>


### PR DESCRIPTION
- still expects pre-built msys/mingw versions of libunbound.dll.a and libunbound-2.dll in external/unbound/.libs
- cmake configure string: cmake [bitmonero-source-dir] -G "Visual Studio 12 2013 Win64" -DBOOST_ROOT=[boost-root-dir] -DSTATIC=OFF
