### PR TITLE
modifying refresh stuff

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -343,10 +343,11 @@ void wallet2::refresh(uint64_t start_height, size_t & blocks_fetched, bool& rece
     catch (const std::exception&)
     {
       blocks_fetched += added_blocks;
-      if(try_count < 3)
+      if(try_count < 300)
       {
         LOG_PRINT_L1("Another try pull_blocks (try_count=" << try_count << ")...");
         ++try_count;
+        sleep(30)
       }
       else
       {


### PR DESCRIPTION
When the refresh in the current condition is not able to finish due to busy server, it cycles 3 times on error and the wallet hang in unstable state which need to be restarted to be restored.

In order to avoid that especially in rpc mode for pool, first need to leverage the try_count to 300 for exemple and adding a sleep 30 into the loop to slow down the looping. This way the rpcwallet is more stable and doesn't need to be restarted when the bitmonerod is not available.