### PR TITLE
DNS seed timeout

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -33,6 +33,8 @@
 #include <string>
 #include <boost/uuid/uuid.hpp>
 
+#define CRYPTONOTE_DNS_TIMEOUT_MS                       20000
+
 #define CRYPTONOTE_MAX_BLOCK_NUMBER                     500000000
 #define CRYPTONOTE_MAX_BLOCK_SIZE                       500000000  // block header blob limit, never used!
 #define CRYPTONOTE_GETBLOCKTEMPLATE_MAX_BLOCK_SIZE	196608 //size of block (bytes) that is the maximum that miners will produce

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -31,6 +31,9 @@
 #pragma once
 
 #include <algorithm>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/thread/thread.hpp> 
+#include <atomic>
 
 #include "version.h"
 #include "string_tools.h"
@@ -46,13 +49,13 @@
 
 // We have to look for miniupnpc headers in different places, dependent on if its compiled or external
 #ifdef UPNP_STATIC
- #include <miniupnpc/miniupnpc.h>
- #include <miniupnpc/upnpcommands.h>
- #include <miniupnpc/upnperrors.h>
+  #include <miniupnpc/miniupnpc.h>
+  #include <miniupnpc/upnpcommands.h>
+  #include <miniupnpc/upnperrors.h>
 #else
- #include "miniupnpc.h"
- #include "upnpcommands.h"
- #include "upnperrors.h"
+  #include "miniupnpc.h"
+  #include "upnpcommands.h"
+  #include "upnperrors.h"
 #endif
 
 #define NET_MAKE_IP(b1,b2,b3,b4)  ((LPARAM)(((DWORD)(b1)<<24)+((DWORD)(b2)<<16)+((DWORD)(b3)<<8)+((DWORD)(b4))))
@@ -252,19 +255,64 @@ namespace nodetool
       // add the result addresses as seed nodes
       // TODO: at some point add IPv6 support, but that won't be relevant
       // for some time yet.
+      
+      std::vector<std::vector<std::string>> dns_results;
+
+      std::vector<std::atomic_flag> dns_finished;
+
+      dns_results.resize(m_seed_nodes_list.size());
+      dns_finished.resize(m_seed_nodes_list.size());
+
+      // set each flag, thread will release when finished
+      for (auto& u : dns_finished)
+        u.test_and_set();
+
+      uint64_t result_index = 0;
       for (const std::string& addr_str : m_seed_nodes_list)
       {
-        // TODO: care about dnssec avail/valid
-        bool avail, valid;
-        std::vector<std::string> addr_list = tools::DNSResolver::instance().get_ipv4(addr_str, avail, valid);
-        for (const std::string& a : addr_list)
+
+        uint64_t result_index_capture = result_index++;
+        boost::thread t([&]
         {
-          append_net_address(m_seed_nodes, a + ":18080");
+          // TODO: care about dnssec avail/valid
+          bool avail, valid;
+          std::vector<std::string> addr_list = tools::DNSResolver().get_ipv4(addr_str, avail, valid);
+
+          dns_results[result_index_capture] = addr_list;
+          dns_finished[result_index_capture].clear();
+        });
+
+      }
+
+      uint64_t sleep_count = 0;
+      uint64_t sleep_interval_ms = 100;
+      while (sleep_count++ * sleep_interval_ms < CRYPTONOTE_DNS_TIMEOUT_MS)
+      {
+        boost::this_thread::sleep(boost::posix_time::milliseconds());
+        bool all_done = false;
+        for (auto& done : dns_finished)
+        {
+          if (done.test_and_set())
+            break;
+          else
+            done.clear();
+          all_done = true;
+        }
+        if (all_done)
+          break;
+      }
+
+      for (const auto& result : dns_results)
+      {
+        for (const auto& addr_string : result)
+        {
+          append_net_address(m_seed_nodes, addr_string + ":18080");
         }
       }
 
       if (!m_seed_nodes.size())
       {
+        LOG_PRINT_L0("DNS seed node lookup either timed out or failed, falling back to defaults");
         append_net_address(m_seed_nodes, "62.210.78.186:18080");
         append_net_address(m_seed_nodes, "195.12.60.154:18080");
         append_net_address(m_seed_nodes, "54.241.246.125:18080");

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -288,7 +288,7 @@ namespace nodetool
       uint64_t sleep_interval_ms = 100;
       while (sleep_count++ * sleep_interval_ms < CRYPTONOTE_DNS_TIMEOUT_MS)
       {
-        boost::this_thread::sleep(boost::posix_time::milliseconds());
+        boost::this_thread::sleep(boost::posix_time::milliseconds(sleep_interval_ms));
         bool all_done = false;
         for (auto& done : dns_finished)
         {


### PR DESCRIPTION
This should resolve daemon startup taking too long by adding a 20 second timeout to DNS seed lookup.  If the time passes and no seeds have been retrieved from DNS then fallback defaults are used.