### PR TITLE
TX's blob size store and add_transaction_from_block optimization/cleanup

### DIFF
--- a/src/cryptonote_core/blockchain_storage.cpp
+++ b/src/cryptonote_core/blockchain_storage.cpp
@@ -1642,10 +1642,12 @@ bool blockchain_storage::handle_block_to_main_chain(const block& bl, const crypt
     bvc.m_verifivation_failed = true;
     return false;
   }
-  size_t coinbase_blob_size = get_object_blobsize(bl.miner_tx);
+  crypto::hash coinbase_hash = null_hash;
+  size_t coinbase_blob_size = 0;
+  get_transaction_hash(bl.miner_tx, coinbase_hash, coinbase_blob_size);
   size_t cumulative_block_size = coinbase_blob_size;
   //process transactions
-  if(!add_transaction_from_block(bl.miner_tx, get_transaction_hash(bl.miner_tx), id, get_current_blockchain_height()))
+  if(!add_transaction_from_block(bl.miner_tx, coinbase_hash, id, get_current_blockchain_height()))
   {
     LOG_PRINT_L1("Block with id: " << id << " failed to add transaction to blockchain storage");
     bvc.m_verifivation_failed = true;

--- a/src/cryptonote_core/blockchain_storage.cpp
+++ b/src/cryptonote_core/blockchain_storage.cpp
@@ -1338,7 +1338,7 @@ bool blockchain_storage::pop_transaction_from_global_index(const transaction& tx
   return true;
 }
 //------------------------------------------------------------------
-bool blockchain_storage::add_transaction_from_block(const transaction& tx, const crypto::hash& tx_id, const crypto::hash& bl_id, uint64_t bl_height)
+bool blockchain_storage::add_transaction_from_block(const transaction& tx, const crypto::hash& tx_id, const crypto::hash& bl_id, uint64_t bl_height, size_t blob_size)
 {
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
   struct add_transaction_input_visitor: public boost::static_visitor<bool>
@@ -1377,6 +1377,7 @@ bool blockchain_storage::add_transaction_from_block(const transaction& tx, const
   }
   transaction_chain_entry ch_e;
   ch_e.m_keeper_block_height = bl_height;
+  ch_e.m_blob_size = blob_size;
   ch_e.tx = tx;
   auto i_r = m_transactions.insert(std::pair<crypto::hash, transaction_chain_entry>(tx_id, ch_e));
   if(!i_r.second)
@@ -1647,7 +1648,7 @@ bool blockchain_storage::handle_block_to_main_chain(const block& bl, const crypt
   get_transaction_hash(bl.miner_tx, coinbase_hash, coinbase_blob_size);
   size_t cumulative_block_size = coinbase_blob_size;
   //process transactions
-  if(!add_transaction_from_block(bl.miner_tx, coinbase_hash, id, get_current_blockchain_height()))
+  if(!add_transaction_from_block(bl.miner_tx, coinbase_hash, id, get_current_blockchain_height(), coinbase_blob_size))
   {
     LOG_PRINT_L1("Block with id: " << id << " failed to add transaction to blockchain storage");
     bvc.m_verifivation_failed = true;
@@ -1681,7 +1682,7 @@ bool blockchain_storage::handle_block_to_main_chain(const block& bl, const crypt
       return false;
     }
 
-    if(!add_transaction_from_block(tx, tx_id, id, get_current_blockchain_height()))
+    if(!add_transaction_from_block(tx, tx_id, id, get_current_blockchain_height(), blob_size))
     {
        LOG_PRINT_L1("Block with id: " << id << " failed to add transaction to blockchain storage");
        cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);

--- a/src/cryptonote_core/blockchain_storage.h
+++ b/src/cryptonote_core/blockchain_storage.h
@@ -233,7 +233,7 @@ namespace cryptonote
     bool validate_miner_transaction(const block& b, size_t cumulative_block_size, uint64_t fee, uint64_t& base_reward, uint64_t already_generated_coins);
     bool validate_transaction(const block& b, uint64_t height, const transaction& tx);
     bool rollback_blockchain_switching(std::list<block>& original_chain, size_t rollback_height);
-    bool add_transaction_from_block(const transaction& tx, const crypto::hash& tx_id, const crypto::hash& bl_id, uint64_t bl_height);
+    bool add_transaction_from_block(const transaction& tx, const crypto::hash& tx_id, const crypto::hash& bl_id, uint64_t bl_height, size_t blob_size);
     bool push_transaction_to_global_outs_index(const transaction& tx, const crypto::hash& tx_id, std::vector<uint64_t>& global_indexes);
     bool pop_transaction_from_global_index(const transaction& tx, const crypto::hash& tx_id);
     bool get_last_n_blocks_sizes(std::vector<size_t>& sz, size_t count);


### PR DESCRIPTION
Use single call to get_transaction_hash to get both transaction hash and blob size. Do actual store of the blob size in transaction_chain_entry struct.