### PR TITLE
DNSSEC changes

### DIFF
--- a/tests/unit_tests/dns_resolver.cpp
+++ b/tests/unit_tests/dns_resolver.cpp
@@ -43,13 +43,13 @@ TEST(DNSResolver, IPv4Success)
 
   ASSERT_EQ(1, ips.size());
 
-  ASSERT_STREQ("93.184.216.119", ips[0].c_str());
+  //ASSERT_STREQ("93.184.216.119", ips[0].c_str());
 
   ips = tools::DNSResolver::instance().get_ipv4("example.com", avail, valid);
 
   ASSERT_EQ(1, ips.size());
 
-  ASSERT_STREQ("93.184.216.119", ips[0].c_str());
+  //ASSERT_STREQ("93.184.216.119", ips[0].c_str());
 }
 
 TEST(DNSResolver, IPv4Failure)
@@ -66,6 +66,38 @@ TEST(DNSResolver, IPv4Failure)
   ips = tools::DNSResolver::instance().get_ipv4("example.invalid", avail, valid);
 
   ASSERT_EQ(0, ips.size());
+}
+
+TEST(DNSResolver, DNSSECSuccess)
+{
+  tools::DNSResolver resolver;
+
+  bool avail, valid;
+
+  auto ips = resolver.get_ipv4("example.com", avail, valid);
+
+  ASSERT_EQ(1, ips.size());
+
+  //ASSERT_STREQ("93.184.216.119", ips[0].c_str());
+
+  ASSERT_TRUE(avail);
+  ASSERT_TRUE(valid);
+}
+
+TEST(DNSResolver, DNSSECFailure)
+{
+  tools::DNSResolver resolver;
+
+  bool avail, valid;
+
+  auto ips = resolver.get_ipv4("dnssec-failed.org", avail, valid);
+
+  ASSERT_EQ(1, ips.size());
+
+  //ASSERT_STREQ("93.184.216.119", ips[0].c_str());
+
+  ASSERT_TRUE(avail);
+  ASSERT_FALSE(valid);
 }
 
 // It would be great to include an IPv6 test and assume it'll pass, but not every ISP / resolver plays nicely with IPv6;)


### PR DESCRIPTION
DNSSEC validation (with hardcoded key from unbound) added.
DNS unit tests for DNSSEC added; unit tests for IPv4 modified for the fact that example.com IP is not static.
DNSSEC enforced as available and valid for MoneroPulse DNS checkpoint updates.