### PR TITLE
Should fix daemon not exiting properly (SIGABRT)

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -114,7 +114,12 @@ bool t_daemon::run()
     mp_internals->core.run();
     mp_internals->rpc.run();
     mp_internals->p2p.run();
-    mp_internals->rpc.stop();
+
+    // the stop() method clears internals
+    if (mp_internals != nullptr)
+    {
+      mp_internals->rpc.stop();
+    }
     LOG_PRINT("Node stopped.", LOG_LEVEL_0);
     return true;
   }

--- a/src/daemonizer/posix_daemonizer.inl
+++ b/src/daemonizer/posix_daemonizer.inl
@@ -49,7 +49,7 @@ namespace daemonizer
       auto daemon = executor.create_daemon(vm);
       tools::success_msg_writer() << "Forking to background...";
       posix::fork();
-      return daemon.run();
+      return daemon.run() ? 0 : 1;
     }
     else
     {

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -495,7 +495,9 @@ namespace nodetool
   bool node_server<t_payload_net_handler>::send_stop_signal()
   {
     m_net_server.send_stop_signal();
-    LOG_PRINT_L0("[node] Stop signal sent");
+    LOG_PRINT_L0("[node] Stop signal sent" << std::endl
+                 << "Please be patient while the daemon shuts down gracefully.");
+    m_net_server.timed_wait_server_stop(5000);
     return true;
   }
   //-----------------------------------------------------------------------------------


### PR DESCRIPTION
Various changes to mutexes, namely spinning timeouts when acquiring
locks to allow threads to join correctly.

Fixed a bug where daemon context was pulled out from under running
threads rather than waiting for them to join.