### PR TITLE
Fixed DNS resolution bug in Windows

### DIFF
--- a/external/unbound/libunbound/libunbound.c
+++ b/external/unbound/libunbound/libunbound.c
@@ -1028,7 +1028,6 @@ ub_ctx_hosts(struct ub_ctx* ctx, const char* fname)
 					"\\hosts");
 				retval=ub_ctx_hosts(ctx, buf);
 			}
-			free(name);
 			return retval;
 		}
 		return UB_READFILE;

--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -162,11 +162,9 @@ DNSResolver::DNSResolver() : m_data(new DNSResolverData())
   // init libunbound context
   m_data->m_ub_context = ub_ctx_create();
 
-  char empty_string = '\0';
-
   // look for "/etc/resolv.conf" and "/etc/hosts" or platform equivalent
-  ub_ctx_resolvconf(m_data->m_ub_context, &empty_string);
-  ub_ctx_hosts(m_data->m_ub_context, &empty_string);
+  ub_ctx_resolvconf(m_data->m_ub_context, NULL);
+  ub_ctx_hosts(m_data->m_ub_context, NULL);
 
   ub_ctx_add_ta(m_data->m_ub_context, ::get_builtin_ds());
 }


### PR DESCRIPTION
Due to a bug in unbound, we were passing a string containing a null
character to ub_ctx_resolvconf and ub_ctx_hosts rather than a NULL
pointer.  On *nix this wasn't causing headache, but on Windows this was
causing unbound to not correctly load DNS settings from the OS.

Note on the bug: in a Windows-specific code branch in the function
ub_ctx_hosts(), if the hosts file specified was a NULL pointer, a call
to getenv() was stored in a local char* and later freed.  This is
incorrect, as we do not own that data, and caused the program to crash.