### PR TITLE
[fix] log level change. compilation: dns, tests

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -172,8 +172,8 @@ namespace net_utils
     /// Construct the server to listen on the specified TCP address and port, and
     /// serve up files from the given directory.
 
-    boosted_tcp_server(t_connection_type connection_type = e_connection_type_NET);
-    explicit boosted_tcp_server(boost::asio::io_service& external_io_service, t_connection_type connection_type = e_connection_type_NET);
+    boosted_tcp_server(t_connection_type connection_type);
+    explicit boosted_tcp_server(boost::asio::io_service& external_io_service, t_connection_type connection_type);
     ~boosted_tcp_server();
     
     std::map<std::string, t_connection_type> server_type_map;

--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -167,7 +167,7 @@ DNSResolver::DNSResolver() : m_data(new DNSResolverData())
   ub_ctx_hosts(m_data->m_ub_context, NULL);
 
 	#ifdef DEVELOPER_LIBUNBOUND_OLD
-		#warning "Using the work around for old libunbound"
+		#pragma message "Using the work around for old libunbound"
 		{ // work around for bug https://www.nlnetlabs.nl/bugs-script/show_bug.cgi?id=515 needed for it to compile on e.g. Debian 7
 			char * ds_copy = NULL; // this will be the writable copy of string that bugged version of libunbound requires
 			try {

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -232,7 +232,7 @@ int main(int argc, char const * argv[])
       else if (epee::log_space::get_set_log_detalisation_level(false) != new_log_level)
       {
         epee::log_space::get_set_log_detalisation_level(true, new_log_level);
-        int otshell_utils_log_level = 100 - (new_log_level * 25);
+        int otshell_utils_log_level = 100 - (new_log_level * 20);
         gCurrentLogger.setDebugLevel(otshell_utils_log_level);
         LOG_PRINT_L0("LOG_LEVEL set to " << new_log_level);
       }

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -35,6 +35,7 @@
 #include "cryptonote_core/cryptonote_core.h"
 #include <boost/format.hpp>
 #include <ctime>
+#include <string>
 
 namespace daemonize {
 
@@ -374,7 +375,7 @@ bool t_rpc_command_executor::set_log_level(int8_t level) {
     }
   }
 
-  tools::success_msg_writer() << "Log level is now " << boost::lexical_cast<std::string>(level);
+  tools::success_msg_writer() << "Log level is now " << std::to_string(level);
 
   return true;
 }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -392,6 +392,8 @@ namespace cryptonote
     else
     {
       epee::log_space::log_singletone::get_set_log_detalisation_level(true, req.level);
+      int otshell_utils_log_level = 100 - (req.level * 20);
+      gCurrentLogger.setDebugLevel(otshell_utils_log_level);
       res.status = CORE_RPC_STATUS_OK;
     }
     return true;

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -34,6 +34,7 @@
 
 #include "cryptonote_core/cryptonote_basic_impl.h"
 #include "cryptonote_core/verification_context.h"
+#include "cryptonote_core/blockchain_storage.h"
 #include <unordered_map>
 
 namespace tests

--- a/tests/net_load_tests/clt.cpp
+++ b/tests/net_load_tests/clt.cpp
@@ -186,6 +186,11 @@ namespace
 
   class net_load_test_clt : public ::testing::Test
   {
+  public:
+    net_load_test_clt()
+    : m_tcp_server(epee::net_utils::e_connection_type_RPC) // RPC disables network limit for unit tests
+    {
+	}
   protected:
     virtual void SetUp()
     {
@@ -237,7 +242,7 @@ namespace
     {
       // Stop server
       test_levin_commands_handler commands_handler;
-      test_tcp_server tcp_server;
+      test_tcp_server tcp_server(epee::net_utils::e_connection_type_NET);
       tcp_server.get_config_object().m_pcommands_handler = &commands_handler;
       tcp_server.get_config_object().m_invoke_timeout = CONNECTION_TIMEOUT;
 

--- a/tests/net_load_tests/srv.cpp
+++ b/tests/net_load_tests/srv.cpp
@@ -223,7 +223,7 @@ int main(int argc, char** argv)
 
   size_t thread_count = (std::max)(min_thread_count, std::thread::hardware_concurrency() / 2);
 
-  test_tcp_server tcp_server;
+  test_tcp_server tcp_server(epee::net_utils::e_connection_type_RPC);
   if (!tcp_server.init_server(srv_port, "127.0.0.1"))
     return 1;
 

--- a/tests/unit_tests/epee_boosted_tcp_server.cpp
+++ b/tests/unit_tests/epee_boosted_tcp_server.cpp
@@ -85,7 +85,7 @@ namespace
 
 TEST(boosted_tcp_server, worker_threads_are_exception_resistant)
 {
-  test_tcp_server srv;
+  test_tcp_server srv(epee::net_utils::e_connection_type_RPC); // RPC disables network limit for unit tests
   ASSERT_TRUE(srv.init_server(test_server_port, test_server_host));
 
   std::mutex mtx;


### PR DESCRIPTION
old unbound #warning does not block compilation
unit tests build fine. Even though the RPC/P2P network type is required again