### PR TITLE
DNS Checkpoint updating-related fixes/changes

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -100,6 +100,8 @@ namespace cryptonote
   {
     if (m_testnet) return true;
 
+    if (m_checkpoints_updating.test_and_set()) return true;
+
     bool res = true;
     if (time(NULL) - m_last_dns_checkpoints_update >= 3600)
     {
@@ -112,6 +114,8 @@ namespace cryptonote
       res = m_blockchain_storage.update_checkpoints(m_checkpoints_path, false);
       m_last_json_checkpoints_update = time(NULL);
     }
+
+    m_checkpoints_updating.clear();
 
     // if anything fishy happened getting new checkpoints, bring down the house
     if (!res)

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -189,6 +189,8 @@ namespace cryptonote
      std::string m_checkpoints_path;
      time_t m_last_dns_checkpoints_update;
      time_t m_last_json_checkpoints_update;
+
+     std::atomic_flag m_checkpoints_updating;
    };
 }
 


### PR DESCRIPTION
Only one thread will be doing the updating.

Two valid responses must match, and the first two that match will be
used.