### PR TITLE
Sort tx by fee per kb

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -488,12 +488,12 @@ namespace cryptonote
     }
 
     for (auto it = m_transactions.begin(); it != m_transactions.end(); ) {
-      auto it2 = it++;
-      if (it2->second.blob_size >= TRANSACTION_SIZE_LIMIT) {
-        LOG_PRINT_L1("Transaction " << get_transaction_hash(it2->second.tx) << " is too big (" << it2->second.blob_size << " bytes), removing it from pool");
-        remove_transaction_keyimages(it2->second.tx);
-        m_transactions.erase(it2);
+      if (it->second.blob_size >= TRANSACTION_SIZE_LIMIT) {
+        LOG_PRINT_L1("Transaction " << get_transaction_hash(it->second.tx) << " is too big (" << it->second.blob_size << " bytes), removing it from pool");
+        remove_transaction_keyimages(it->second.tx);
+        m_transactions.erase(it);
       }
+      it++;
     }
 
     // Ignore deserialization error

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -34,6 +34,7 @@
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
+#include <queue>
 #include <boost/serialization/version.hpp>
 #include <boost/utility.hpp>
 
@@ -130,6 +131,12 @@ namespace cryptonote
     transactions_container m_transactions;
     key_images_container m_spent_key_images;
     epee::math_helper::once_a_time_seconds<30> m_remove_stuck_tx_interval;
+
+    typedef std::unordered_map<crypto::hash, double> tx_by_fee_entry;
+
+    //TODO: add fee_per_kb element to type tx_details and replace this
+    //functionality by just making m_transactions a std::set
+    std::set<tx_by_fee_entry> m_txs_by_fee;
 
     //transactions_container m_alternative_transactions;
 


### PR DESCRIPTION
It is best for miners (and makes sense) to sort transactions by fee per byte (or kb) used.

This PR addresses that and should sort it completely.