### PR TITLE
Fixes for compilation on clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,7 @@ else()
   else()
     set(ARCH_FLAG "-march=${ARCH}")
   endif()
-  set(WARNINGS "-Wall -Wextra -Wpointer-arith -Wundef -Wvla -Wwrite-strings -Wno-error=extra -Wno-error=deprecated-declarations -Wno-error=sign-compare -Wno-error=strict-aliasing -Wno-error=type-limits -Wno-unused-parameter -Wno-error=unused-variable -Wno-error=undef -Wno-error=uninitialized")
+  set(WARNINGS "-Wall -Wextra -Wpointer-arith -Wundef -Wvla -Wwrite-strings -Wno-error=extra -Wno-error=deprecated-declarations -Wno-error=sign-compare -Wno-error=strict-aliasing -Wno-error=type-limits -Wno-unused-parameter -Wno-error=unused-variable -Wno-error=undef -Wno-error=uninitialized -Wno-deprecated-register")
   if(NOT MINGW)
     set(WARNINGS "${WARNINGS} -Werror") # to allow pedantic but not stop compilation
   endif()

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -82,15 +82,16 @@ namespace nodetool
 
     node_server(t_payload_net_handler& payload_handler)
 		:m_payload_handler(payload_handler),
+    m_current_number_of_out_peers(0),
 		m_allow_local_ip(false),
-		m_no_igd(false),
 		m_hide_my_port(false),
+    m_no_igd(false),
+    m_save_graph(false),
+    is_closing(false),
 		m_net_server( epee::net_utils::e_connection_type_P2P ) // this is a P2P connection of the main p2p node server, because this is class node_server<>
-    {
-		m_current_number_of_out_peers = 0;
-		m_save_graph = false;
-		is_closing = false;
-	}
+    {}
+    virtual ~node_server()
+    {}
 
     static void init_options(boost::program_options::options_description& desc);
 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -97,7 +97,6 @@ namespace nodetool
     
     const command_line::arg_descriptor<bool>		arg_save_graph			= {"save-graph", "Save data for dr monero", false};
   }
-
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
   void node_server<t_payload_net_handler>::init_options(boost::program_options::options_description& desc)
@@ -116,9 +115,9 @@ namespace nodetool
     command_line::add_arg(desc, arg_out_peers);
     command_line::add_arg(desc, arg_tos_flag);
     command_line::add_arg(desc, arg_limit_rate_up);
-  	command_line::add_arg(desc, arg_limit_rate_down);
-  	command_line::add_arg(desc, arg_limit_rate);
-  	command_line::add_arg(desc, arg_save_graph);
+    command_line::add_arg(desc, arg_limit_rate_down);
+    command_line::add_arg(desc, arg_limit_rate);
+    command_line::add_arg(desc, arg_save_graph);
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>


### PR DESCRIPTION
Fix two warnings arising (and causing compilation to fail) when compiling Monero on OSX Mavericks with clang:
* Deprecated 'register' storage class warning in boost.uuid
* Missing virtual destructor for node_server
