### PR TITLE
Support debugging command --pop-blocks on in-memory blockchain

### DIFF
--- a/src/cryptonote_core/blockchain_storage.h
+++ b/src/cryptonote_core/blockchain_storage.h
@@ -190,6 +190,9 @@ namespace cryptonote
     difficulty_type get_block_cumulative_difficulty(uint64_t height) const { return m_blocks[height].cumulative_difficulty; }
     uint64_t get_block_coins_generated(uint64_t height) const { return m_blocks[height].already_generated_coins; }
 
+    // use for testing only
+    bool debug_pop_block_from_blockchain() { return pop_block_from_blockchain(); }
+
   private:
     typedef std::unordered_map<crypto::hash, size_t> blocks_by_id_index;
     typedef std::unordered_map<crypto::hash, transaction_chain_entry> transactions_container;


### PR DESCRIPTION
Add public method blockchain_storage::debug_pop_block_from_blockchain()

Ensure blockchain_import calls destructors before exit.

To test:

DATABASE=memory make release

// create blockchain.bin from blockchain.raw if needed
build/release/bin/blockchain_import --block-stop 1000

// try popping a single block
build/release/bin/blockchain_import --pop-blocks 1