### PR TITLE
Fix compile for GCC 5.1.0

### DIFF
--- a/contrib/epee/include/storages/portable_storage.h
+++ b/contrib/epee/include/storages/portable_storage.h
@@ -427,7 +427,7 @@ namespace epee
       TRY_ENTRY();
       CHECK_AND_ASSERT(hsec_array, false);
       if(hsec_array->type() != typeid(array_entry_t<section>))
-        return nullptr;
+        return false;
       array_entry_t<section>& sec_array = boost::get<array_entry_t<section>>(*hsec_array);
       h_child_section = sec_array.get_next_val();
       if(!h_child_section)

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1194,6 +1194,10 @@ namespace nodetool
       std::string port_=port;
       peerid_type pr_ = pr;
       auto cb_ = cb;*/
+
+      // GCC 5.1.0 gives error with second use of uint64_t (peerid_type) variable.
+      peerid_type pr_ = pr;
+
       bool inv_call_res = epee::net_utils::async_invoke_remote_command2<COMMAND_PING::response>(ping_context.m_connection_id, COMMAND_PING::ID, req, m_net_server.get_config_object(),
         [=](int code, const COMMAND_PING::response& rsp, p2p_connection_context& context)
       {
@@ -1205,7 +1209,7 @@ namespace nodetool
 
         if(rsp.status != PING_OK_RESPONSE_STATUS_TEXT || pr != rsp.peer_id)
         {
-          LOG_PRINT_CC_L2(ping_context, "back ping invoke wrong response \"" << rsp.status << "\" from" << ip << ":" << port << ", hsh_peer_id=" << pr << ", rsp.peer_id=" << rsp.peer_id);
+          LOG_PRINT_CC_L2(ping_context, "back ping invoke wrong response \"" << rsp.status << "\" from" << ip << ":" << port << ", hsh_peer_id=" << pr_ << ", rsp.peer_id=" << rsp.peer_id);
           return;
         }
         m_net_server.get_config_object().close(ping_context.m_connection_id);


### PR DESCRIPTION
Add fix for compile error with multiple uses of peerid_type (uint64_t) variable in lambda expression.
- known GCC issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65843

epee: replace return value of nullptr for expected boolean with false.

Fixes #231.