### PR TITLE
properly decrement p2p socket count

### DIFF
--- a/src/p2p/connection_basic.cpp
+++ b/src/p2p/connection_basic.cpp
@@ -169,6 +169,7 @@ connection_basic::connection_basic(boost::asio::io_service& io_service, std::ato
 
 connection_basic::~connection_basic() {
 	string remote_addr_str = "?";
+	m_ref_sock_count--;
 	try { remote_addr_str = socket_.remote_endpoint().address().to_string(); } catch(...){} ;
 	_note("Destructing connection p2p#"<<mI->m_peer_number << " to " << remote_addr_str);
 }


### PR DESCRIPTION
Near as I can tell, if connection_basic is incrementing the sock count in the constructor it should decrement it in the destructor.