### PR TITLE
Set dnssec_valid value correctly in dns_utils; fix address_from_url test

### DIFF
--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -232,7 +232,7 @@ std::vector<std::string> DNSResolver::get_ipv4(const std::string& url, bool& dns
   if (!ub_resolve(m_data->m_ub_context, urlC, DNS_TYPE_A, DNS_CLASS_IN, &result))
   {
     dnssec_available = (result->secure || (!result->secure && result->bogus));
-    dnssec_valid = !result->bogus;
+    dnssec_valid = result->secure && !result->bogus;
     if (result->havedata)
     {
       for (size_t i=0; result->data[i] != NULL; i++)
@@ -263,7 +263,7 @@ std::vector<std::string> DNSResolver::get_ipv6(const std::string& url, bool& dns
   if (!ub_resolve(m_data->m_ub_context, urlC, DNS_TYPE_AAAA, DNS_CLASS_IN, &result))
   {
     dnssec_available = (result->secure || (!result->secure && result->bogus));
-    dnssec_valid = !result->bogus;
+    dnssec_valid = result->secure && !result->bogus;
     if (result->havedata)
     {
       for (size_t i=0; result->data[i] != NULL; i++)
@@ -294,7 +294,7 @@ std::vector<std::string> DNSResolver::get_txt_record(const std::string& url, boo
   if (!ub_resolve(m_data->m_ub_context, urlC, DNS_TYPE_TXT, DNS_CLASS_IN, &result))
   {
     dnssec_available = (result->secure || (!result->secure && result->bogus));
-    dnssec_valid = !result->bogus;
+    dnssec_valid = result->secure && !result->bogus;
     if (result->havedata)
     {
       for (size_t i=0; result->data[i] != NULL; i++)

--- a/tests/unit_tests/address_from_url.cpp
+++ b/tests/unit_tests/address_from_url.cpp
@@ -109,7 +109,8 @@ TEST(AddressFromURL, Failure)
 
   std::vector<std::string> addresses = tools::wallet2::addresses_from_url("example.invalid", dnssec_result);
 
-  ASSERT_FALSE(dnssec_result);
+  // for a non-existing domain such as "example.invalid", the non-existence is proved with NSEC records
+  ASSERT_TRUE(dnssec_result);
 
   ASSERT_EQ(0, addresses.size());
 }


### PR DESCRIPTION
I've found that the dnssec_valid value was being wrongly let to true when it should be false. We must check not only `result->bogus`, but also `result->secure`, since `result->bogus` is 0 when dnssec isn't available for the given domain.

This PR also fixes one unit test where we query a non-existing top-level domain, and libunbound validates the non-existence with dnssec and sets `secure` to 1.