### PR TITLE
mnemonics: fix duplicate symbol error

### DIFF
--- a/src/mnemonics/language_base.h
+++ b/src/mnemonics/language_base.h
@@ -52,7 +52,7 @@ namespace Language
    * \param  count           How many characters to return.
    * \return                 A string consisting of the first count characters in s.
    */
-  std::string utf8prefix(const std::string &s, size_t count)
+  inline std::string utf8prefix(const std::string &s, size_t count)
   {
     std::string prefix = "";
     const char *ptr = s.c_str();


### PR DESCRIPTION
Fix the following compile error in the tests on gcc 4.8.2:
```
electrum-words.cpp.o (symbol from plugin): In function `Language::utf8prefix(std::string const&, unsigned long)':
(.text+0x0): multiple definition of `Language::utf8prefix(std::string const&, unsigned long)'
CMakeFiles/unit_tests.dir/mnemonics.cpp.o (symbol from plugin):(.text+0x0): first defined here
collect2: error: ld returned 1 exit status
```