### PR TITLE
wallet: add boolean to always confirm transactions with the user

### DIFF
--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -98,6 +98,7 @@ namespace cryptonote
      * \return success status
      */
     bool seed_set_language(const std::vector<std::string> &args = std::vector<std::string>());
+    bool set_always_confirm_transfers(const std::vector<std::string> &args = std::vector<std::string>());
     bool help(const std::vector<std::string> &args = std::vector<std::string>());
     bool start_mining(const std::vector<std::string> &args);
     bool stop_mining(const std::vector<std::string> &args);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -502,6 +502,9 @@ bool wallet2::store_keys(const std::string& keys_file_name, const std::string& p
   value2.SetInt(watch_only ? 1 :0); // WTF ? JSON has different true and false types, and not boolean ??
   json.AddMember("watch_only", value2, json.GetAllocator());
 
+  value2.SetInt(m_always_confirm_transfers ? 1 :0);
+  json.AddMember("always_confirm_transfers", value2, json.GetAllocator());
+
   // Serialize the JSON object
   rapidjson::StringBuffer buffer;
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
@@ -562,6 +565,7 @@ void wallet2::load_keys(const std::string& keys_file_name, const std::string& pa
   {
     is_old_file_format = true;
     m_watch_only = false;
+    m_always_confirm_transfers = false;
   }
   else
   {
@@ -580,6 +584,7 @@ void wallet2::load_keys(const std::string& keys_file_name, const std::string& pa
     {
       m_watch_only = false;
     }
+    m_always_confirm_transfers = json.HasMember("always_confirm_transfers") && (json["always_confirm_transfers"].GetInt() != 0);
   }
 
   const cryptonote::account_keys& keys = m_account.get_keys();

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -80,7 +80,7 @@ namespace tools
 
   class wallet2
   {
-    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false) {};
+    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers (false) {};
   public:
     wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_restricted(restricted), is_old_file_format(false) {};
     struct transfer_details
@@ -266,6 +266,10 @@ namespace tools
     static std::vector<std::string> addresses_from_url(const std::string& url, bool& dnssec_valid);
 
     static std::string address_from_txt_record(const std::string& s);
+
+    bool always_confirm_transfers() const { return m_always_confirm_transfers; }
+    void always_confirm_transfers(bool always) { m_always_confirm_transfers = always; }
+
   private:
     /*!
      * \brief  Stores wallet information to wallet file.
@@ -319,6 +323,7 @@ namespace tools
     std::string seed_language; /*!< Language of the mnemonics (seed). */
     bool is_old_file_format; /*!< Whether the wallet file is of an old file format */
     bool m_watch_only; /*!< no spend key */
+    bool m_always_confirm_transfers;
   };
 }
 BOOST_CLASS_VERSION(tools::wallet2, 7)


### PR DESCRIPTION
This can be useful if you want to be given a veto over the tx fee,
or if you want to see what a tx fee would be without actually sending.