### PR TITLE
simplewallet: use unsigned long long instead of size_t in message

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -1421,9 +1421,9 @@ bool simple_wallet::transfer(const std::vector<std::string> &args_)
           total_fee += ptx_vector[n].fee;
         }
 
-        std::string prompt_str = (boost::format(tr("Your transaction needs to be split into %u transactions.  "
+        std::string prompt_str = (boost::format(tr("Your transaction needs to be split into %llu transactions.  "
           "This will result in a transaction fee being applied to each transaction, for a total fee of %s.  Is this okay?  (Y/Yes/N/No)")) %
-          ptx_vector.size() % print_money(total_fee)).str();
+          ((unsigned long long)ptx_vector.size()) % print_money(total_fee)).str();
         std::string accepted = command_line::input_line(prompt_str);
         if (accepted != "Y" && accepted != "y" && accepted != "Yes" && accepted != "yes")
         {
@@ -1552,9 +1552,9 @@ bool simple_wallet::sweep_dust(const std::vector<std::string> &args_)
 
     std::string prompt_str = tr("Sweeping ") + print_money(total_dust);
     if (ptx_vector.size() > 1) {
-      prompt_str = (boost::format(tr("Sweeping %s in %u transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No)")) %
+      prompt_str = (boost::format(tr("Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No)")) %
         print_money(total_dust) %
-        ptx_vector.size() %
+        ((unsigned long long)ptx_vector.size()) %
         print_money(total_fee)).str();
     }
     else {

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -169,7 +169,7 @@ namespace cryptonote
 
         if (std::chrono::milliseconds(1) < current_time - m_print_time || force)
         {
-          std::cout << QT_TRANSLATE_NOOP("Height ", "cryptonote::simple_wallet") << height << " / " << m_blockchain_height << '\r';
+          std::cout << QT_TRANSLATE_NOOP("cryptonote::simple_wallet", "Height ") << height << " / " << m_blockchain_height << '\r';
           m_print_time = current_time;
         }
       }

--- a/translations/monero.ts
+++ b/translations/monero.ts
@@ -4,310 +4,310 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="217"/>
         <source>Commands: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="250"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="248"/>
         <source>This wallet is watch-only and cannot have a seed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="270"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="268"/>
         <source>The wallet is non-deterministic. Cannot display seed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="280"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="278"/>
         <source>This wallet is watch-only and doesn&apos;t have a seed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="285"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="283"/>
         <source>This wallet is non-deterministic and doesn&apos;t have a seed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="292"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="322"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="556"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="918"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="925"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="554"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="923"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="300"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="298"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="328"/>
         <source>invalid password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="315"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="313"/>
         <source>This wallet is watch-only and cannot transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="349"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="347"/>
         <source>start_mining [&lt;number_of_threads&gt;] - Start mining in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="350"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="348"/>
         <source>Stop mining in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="351"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="349"/>
         <source>Save current blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="352"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="350"/>
         <source>Resynchronize transactions and balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="353"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="351"/>
         <source>Show current wallet balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="354"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="352"/>
         <source>incoming_transfers [available|unavailable] - Show incoming transfers - all of them or filter them by availability</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="355"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="353"/>
         <source>payments &lt;payment_id_1&gt; [&lt;payment_id_2&gt; ... &lt;payment_id_N&gt;] - Show payments &lt;payment_id_1&gt;, ... &lt;payment_id_N&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="356"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="354"/>
         <source>Show blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="357"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="355"/>
         <source>transfer [&lt;mixin_count&gt;] &lt;addr_1&gt; &lt;amount_1&gt; [&lt;addr_2&gt; &lt;amount_2&gt; ... &lt;addr_N&gt; &lt;amount_N&gt;] [payment_id] - Transfer &lt;amount_1&gt;,... &lt;amount_N&gt; to &lt;address_1&gt;,... &lt;address_N&gt;, respectively. &lt;mixin_count&gt; is the number of transactions yours is indistinguishable from (from 0 to maximum available)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="358"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="356"/>
         <source>Send all dust outputs to the same address with mixin 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="359"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="357"/>
         <source>set_log &lt;level&gt; - Change current log detalization level, &lt;level&gt; is a number 0-4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="360"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="358"/>
         <source>Show current wallet public address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="361"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="359"/>
         <source>Convert a payment ID to an integrated address for the current wallet public address (no arguments use a random payment ID), or display standard addres and payment ID corresponding to an integrated addres</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="362"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="360"/>
         <source>Save wallet synchronized data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="363"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="361"/>
         <source>Save watch only keys file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="362"/>
         <source>Get viewkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="365"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="363"/>
         <source>Get spendkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="366"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="364"/>
         <source>Get deterministic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="368"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="366"/>
         <source>Show this help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="367"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="365"/>
         <source>available options: seed language - Set wallet seed langage; always-confirm-transfers &lt;1|0&gt; - whether to confirm unsplit txes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="375"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="373"/>
         <source>set: needs an argument. available options: seed, always-confirm-transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="384"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="382"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="399"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="397"/>
         <source>set always-confirm-transfers: needs an argument (0 or 1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="411"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="409"/>
         <source>set: unrecognized argument(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="419"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="417"/>
         <source>use: set_log &lt;log_level_number_0-4&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="425"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="423"/>
         <source>wrong number format, use: set_log &lt;log_level_number_0-4&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="430"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="428"/>
         <source>wrong number range, use: set_log &lt;log_level_number_0-4&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="443"/>
         <source>Specify wallet file name (e.g., wallet.bin). If the wallet doesn&apos;t exist, it will be created.
 Wallet file name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="451"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="817"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="815"/>
         <source>wallet file path not valid: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="470"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="468"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="482"/>
         <source>The wallet doesn&apos;t exist, generating new one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="489"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="487"/>
         <source>Keys file wasn&apos;t found: failed to open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="503"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="501"/>
         <source>PLEASE NOTE: the following 25 words can be used to recover access to your wallet. Please write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="519"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="517"/>
         <source>you can&apos;t specify daemon host or port several times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="525"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
         <source>Specifying more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot; and --generate-from-keys doesn&apos;t make sense!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="569"/>
         <source>Cannot specify both --restore-deterministic-wallet and --non-deterministic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="580"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="578"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="587"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="585"/>
         <source>electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="596"/>
         <source>--generate-from-view-key needs a address:viewkey:filename triple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="606"/>
         <source>Failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="616"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="614"/>
         <source>Failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="670"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="668"/>
         <source>wallet failed to connect to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="671"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="669"/>
         <source>Daemon either is not started or passed wrong port. Please, make sure that daemon is running or restart the wallet with correct daemon address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="691"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="689"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="700"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="698"/>
         <source>Enter the number corresponding to the language of your choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="707"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="712"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="705"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="710"/>
         <source>Invalid language choice passed. Please try again.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="735"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="733"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="751"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="749"/>
         <source>Generated new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="800"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="751"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="798"/>
         <source>view key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="757"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="804"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="755"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="802"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="768"/>
         <source>Your wallet has been generated.
 To start synchronizing with the daemon use &quot;refresh&quot; command.
 Use &quot;help&quot; command to see the list of available commands.
@@ -318,509 +318,509 @@ your wallet again. Your wallet key is NOT under risk anyway.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="798"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="796"/>
         <source>Generated new watch-only wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="829"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="827"/>
         <source>Opened watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="829"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="827"/>
         <source>Opened wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="836"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="851"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="849"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="859"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="857"/>
         <source>failed to load wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="866"/>
         <source>Use &quot;help&quot; command to see the list of available commands.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="878"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="876"/>
         <source>failed to deinit wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="900"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="898"/>
         <source>Wallet data saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="913"/>
         <source>Password for the new watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="920"/>
         <source>Enter new password again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="930"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="928"/>
         <source>passwords do not match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="965"/>
         <source>invalid arguments. Please use start_mining [&lt;number_of_threads&gt;], &lt;number_of_threads&gt; should be from 1 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="974"/>
         <source>Mining started in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="978"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="976"/>
         <source>mining has NOT been started: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="992"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="990"/>
         <source>Mining stopped in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="992"/>
         <source>mining has NOT been stopped: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
         <source>Blockchain saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1010"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1008"/>
         <source>Blockchain can&apos;t be saved: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1022"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1031"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1040"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1020"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1029"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1038"/>
         <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1023"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1032"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1041"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1039"/>
         <source>transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1024"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1022"/>
         <source>received </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1033"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1031"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1042"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1040"/>
         <source>unsupported transaction format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1049"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1074"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1072"/>
         <source>Refresh done, blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1446"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1077"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1588"/>
         <source>daemon is busy. Please try later</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1083"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1081"/>
         <source>no connection to daemon. Please, make sure daemon is running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1088"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1455"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1592"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1086"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1460"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1597"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1093"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1091"/>
         <source>Error refreshing: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1098"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1506"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1096"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1511"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1648"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1103"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1511"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1648"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1101"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1653"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1108"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1516"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1653"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1521"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1658"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1111"/>
         <source>refresh failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1111"/>
         <source>Blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1121"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1119"/>
         <source>balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1120"/>
         <source>unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1121"/>
         <source>including unlocked dust: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1155"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1153"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1193"/>
         <source>amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1155"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1153"/>
         <source>spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1155"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1153"/>
         <source>global index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1155"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1153"/>
         <source>tx id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1171"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1169"/>
         <source>No incoming transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1175"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1173"/>
         <source>No incoming available transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1179"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1177"/>
         <source>No incoming unavailable transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1190"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1188"/>
         <source>expected at least one payment_id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1193"/>
         <source>payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1193"/>
         <source>transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1193"/>
         <source>height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1193"/>
         <source>unlock time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1207"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1205"/>
         <source>No payments with id </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1308"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1306"/>
         <source>payment id has invalid format, expected 64-character string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1252"/>
         <source>failed to get blockchain height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1278"/>
         <source>wrong number of arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1286"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1530"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1284"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1535"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1341"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1339"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1345"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1343"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1346"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1348"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1352"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
         <source>Is this OK? (Y/n) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1358"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1356"/>
         <source>yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1358"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1356"/>
         <source>no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1360"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1358"/>
         <source>You have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1366"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1364"/>
         <source>Failed to get a Monero address from: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1372"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1370"/>
         <source>Not yet supported: Multiple Monero addresses found for given URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1374"/>
         <source>Wrong address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1383"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1381"/>
         <source>A single transaction cannot use more than one payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1394"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1392"/>
         <source>Failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1402"/>
         <source>amount is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1405"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1403"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1420"/>
-        <source>Your transaction needs to be split into %u transactions.  This will result in a transaction fee being applied to each transaction.  Is this okay?  (Y/Yes/N/No)</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1424"/>
+        <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s.  Is this okay?  (Y/Yes/N/No)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1550"/>
-        <source>Sweeping %s in %u transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1425"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1563"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1430"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
         <source>Transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1438"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1443"/>
         <source>Money successfully sent, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1587"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1455"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1592"/>
         <source>no connection to daemon. Please, make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1459"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1464"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1601"/>
         <source>failed to get random outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1463"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1600"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1468"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1605"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1609"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1477"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1614"/>
         <source>not enough outputs for specified mixin_count</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1475"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1612"/>
-        <source>output amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1475"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1612"/>
-        <source>found outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1480"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1617"/>
+        <source>output amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1480"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1617"/>
+        <source>found outputs to mix</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1485"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1484"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1621"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1489"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1626"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1629"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1497"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1634"/>
         <source>one of destinations is zero</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1496"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1633"/>
-        <source>Failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1501"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1638"/>
+        <source>Failed to find a suitable way to split transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1506"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1548"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1553"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1556"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1555"/>
+        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1561"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1575"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1580"/>
         <source>Money successfully sent, transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1662"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1667"/>
         <source>wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1682"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1687"/>
         <source>integrated_address only takes one or zero arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1688"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1693"/>
         <source>Random payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1689"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1694"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1705"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1710"/>
         <source>Integrated address: account %s, payment id %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1710"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1715"/>
         <source>Standard address: account: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1715"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1720"/>
         <source>Failed to parse payment id or address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -908,104 +908,104 @@ your wallet again. Your wallet key is NOT under risk anyway.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="209"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="207"/>
         <source>yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1734"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1739"/>
         <source>General options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1738"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1743"/>
         <source>Wallet options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1751"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1756"/>
         <source>default_log: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1783"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1814"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1781"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1788"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1819"/>
         <source>wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1777"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1782"/>
         <source>Usage:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1819"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1824"/>
         <source>Logging at log level %d to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1829"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1834"/>
         <source>Wallet file not set.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1834"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1839"/>
         <source>Daemon address not set.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1839"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1844"/>
         <source>Wallet password not set.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1860"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1865"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1864"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1869"/>
         <source>Loaded ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1868"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1873"/>
         <source>Wallet initialization failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1873"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1878"/>
         <source>Failed to initialize wallet rpc server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1879"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1884"/>
         <source>Starting wallet rpc server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1881"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1886"/>
         <source>Stopped wallet rpc server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1884"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1889"/>
         <source>Storing wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1886"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1891"/>
         <source>Stored ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1890"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1895"/>
         <source>Failed to store wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1897"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1902"/>
         <source>Failed to initialize wallet</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
boost doesn't support %zu for size_t, and the previous change
to %u could technically lose bits (though it would require splitting
a transfer into 4 billion transactions, which seems unlikely).