### PR TITLE
Fix block_reward unit tests

### DIFF
--- a/tests/unit_tests/block_reward.cpp
+++ b/tests/unit_tests/block_reward.cpp
@@ -49,28 +49,28 @@ namespace
   #define TEST_ALREADY_GENERATED_COINS(already_generated_coins, expected_reward)                            \
     m_block_not_too_big = get_block_reward(0, current_block_size, already_generated_coins, m_block_reward); \
     ASSERT_TRUE(m_block_not_too_big);                                                                       \
-    ASSERT_EQ(m_block_reward, UINT64_C(expected_reward));
+    ASSERT_EQ(m_block_reward, expected_reward);
 
   TEST_F(block_reward_and_already_generated_coins, handles_first_values)
   {
   	// 17592186044415 from neozaru, confirmed by fluffypony
-    TEST_ALREADY_GENERATED_COINS(0, 17592186044415);
-    TEST_ALREADY_GENERATED_COINS(m_block_reward, 17592169267200);
-    TEST_ALREADY_GENERATED_COINS(UINT64_C(2756434948434199641), 14963444829249);
+    TEST_ALREADY_GENERATED_COINS(0, UINT64_C(17592186044415));
+    TEST_ALREADY_GENERATED_COINS(m_block_reward, UINT64_C(17592169267200));
+    TEST_ALREADY_GENERATED_COINS(UINT64_C(2756434948434199641), UINT64_C(14963444829249));
   }
 
   TEST_F(block_reward_and_already_generated_coins, correctly_steps_from_2_to_1)
   {
-    TEST_ALREADY_GENERATED_COINS(MONEY_SUPPLY - ((2 << 20) + 1), 2);
-    TEST_ALREADY_GENERATED_COINS(MONEY_SUPPLY -  (2 << 20)     , 2);
-    TEST_ALREADY_GENERATED_COINS(MONEY_SUPPLY - ((2 << 20) - 1), 1);
+    TEST_ALREADY_GENERATED_COINS(MONEY_SUPPLY - ((2 << 20) + 1), FINAL_SUBSIDY_PER_MINUTE);
+    TEST_ALREADY_GENERATED_COINS(MONEY_SUPPLY -  (2 << 20)     , FINAL_SUBSIDY_PER_MINUTE);
+    TEST_ALREADY_GENERATED_COINS(MONEY_SUPPLY - ((2 << 20) - 1), FINAL_SUBSIDY_PER_MINUTE);
   }
 
   TEST_F(block_reward_and_already_generated_coins, handles_max)
   {
-    TEST_ALREADY_GENERATED_COINS(MONEY_SUPPLY - ((1 << 20) + 1), 1);
-    TEST_ALREADY_GENERATED_COINS(MONEY_SUPPLY -  (1 << 20)     , 1);
-    TEST_ALREADY_GENERATED_COINS(MONEY_SUPPLY - ((1 << 20) - 1), 0);
+    TEST_ALREADY_GENERATED_COINS(MONEY_SUPPLY - ((1 << 20) + 1), FINAL_SUBSIDY_PER_MINUTE);
+    TEST_ALREADY_GENERATED_COINS(MONEY_SUPPLY -  (1 << 20)     , FINAL_SUBSIDY_PER_MINUTE);
+    TEST_ALREADY_GENERATED_COINS(MONEY_SUPPLY - ((1 << 20) - 1), FINAL_SUBSIDY_PER_MINUTE);
   }
 
   //--------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Now we should take FINAL_SUBSIDY_PER_MINUTE into account