### PR TITLE
wallet: new rescan_spent command to update outputs' spent status

### DIFF
--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -120,6 +120,7 @@ namespace cryptonote
     bool save(const std::vector<std::string> &args);
     bool save_watch_only(const std::vector<std::string> &args);
     bool set_variable(const std::vector<std::string> &args);
+    bool rescan_spent(const std::vector<std::string> &args);
     bool set_log(const std::vector<std::string> &args);
 
     uint64_t get_daemon_blockchain_height(std::string& err);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -235,6 +235,7 @@ namespace tools
     void get_payments(const crypto::hash& payment_id, std::list<wallet2::payment_details>& payments, uint64_t min_height = 0) const;
     void get_payments(std::list<std::pair<crypto::hash,wallet2::payment_details>>& payments, uint64_t min_height) const;
     uint64_t get_blockchain_current_height() const { return m_local_bc_height; }
+    void rescan_spent();
     template <class t_archive>
     inline void serialize(t_archive &a, const unsigned int ver)
     {

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -73,6 +73,7 @@ namespace tools
     //       wallet_rpc_error *
     //         daemon_busy
     //         no_connection_to_daemon
+    //         is_key_image_spent_error
     //       wallet_files_doesnt_correspond
     //
     // * - class with protected ctor
@@ -570,6 +571,14 @@ namespace tools
     {
       explicit no_connection_to_daemon(std::string&& loc, const std::string& request)
         : wallet_rpc_error(std::move(loc), "no connection to daemon", request)
+      {
+      }
+    };
+    //----------------------------------------------------------------------------------------------------
+    struct is_key_image_spent_error : public wallet_rpc_error
+    {
+      explicit is_key_image_spent_error(std::string&& loc, const std::string& request)
+        : wallet_rpc_error(std::move(loc), "error from is_key_image_spent call", request)
       {
       }
     };


### PR DESCRIPTION
This obsoletes the need for a lengthy blockchain rescan when
a transaction doesn't end up in the chain after being accepted
by the daemon, or any other reason why the wallet's idea of
spent and unspent outputs gets out of sync from the blockchain's.