### PR TITLE
core_rpc_server: replace vector<bool> with vector<int> in RPC

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -259,12 +259,16 @@ namespace cryptonote
       }
       key_images.push_back(*reinterpret_cast<const crypto::key_image*>(b.data()));
     }
-    bool r = m_core.are_key_images_spent(key_images, res.spent_status);
+    std::vector<bool> spent_status;
+    bool r = m_core.are_key_images_spent(key_images, spent_status);
     if(!r)
     {
       res.status = "Failed";
       return true;
     }
+    res.spent_status.clear();
+    for (size_t n = 0; n < spent_status.size(); ++n)
+      res.spent_status.push_back(spent_status[n]);
 
     res.status = CORE_RPC_STATUS_OK;
     return true;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -131,7 +131,7 @@ namespace cryptonote
 
     struct response
     {
-      std::vector<bool> spent_status;
+      std::vector<int> spent_status;
       std::string status;
 
       BEGIN_KV_SERIALIZE_MAP()


### PR DESCRIPTION
vector<bool> causes issues in serialization with Boost 1.56