### PR TITLE
simplewallet: Use default log file name when executable's file path is unknown

### DIFF
--- a/contrib/epee/include/misc_log_ex.h
+++ b/contrib/epee/include/misc_log_ex.h
@@ -861,7 +861,8 @@ namespace log_space
       std::string::size_type a = m_default_log_file.rfind('.');
       if ( a != std::string::npos )
         m_default_log_file.erase( a, m_default_log_file.size());
-      m_default_log_file += ".log";
+      if ( ! m_default_log_file.empty() )
+        m_default_log_file += ".log";
 
       return true;
     }


### PR DESCRIPTION
Default to "simplewallet.log" in current directory when file path isn't obtained from epee.

In this situation previously, it defaulted to the file name of `.log` ("" + ".log") in the current directory.
(Thanks to @sammy007 for reporting bug.)

An earlier version yet used "" + "/" + ".log" = `/.log`, which resulted in silently not logging in most cases, due to lack of permission.

Test:
`PATH=$PATH:</path/to/simplewallet/folder> && simplewallet --wallet-file /dev/null`

This results in epee not finding the executable's file path, so simplewallet will now use a default log filename.