### PR TITLE
Revert f4ba92bcccd3e016c6b5fdced079bf17d1b3f371

### DIFF
--- a/external/unbound/libunbound/libunbound.c
+++ b/external/unbound/libunbound/libunbound.c
@@ -1037,7 +1037,6 @@ ub_ctx_hosts(struct ub_ctx* ctx, const char* fname)
 					"\\hosts");
 				retval=ub_ctx_hosts(ctx, buf);
 			}
-			free(name);
 			return retval;
 		}
 		return UB_READFILE;


### PR DESCRIPTION
Looks like Unbound has been fixed so that this is no longer an issue, yay!