### PR TITLE
wallet: encrypt the cache file

### DIFF
--- a/src/crypto/chacha8.h
+++ b/src/crypto/chacha8.h
@@ -70,12 +70,16 @@ namespace crypto {
     chacha8(data, length, reinterpret_cast<const uint8_t*>(&key), reinterpret_cast<const uint8_t*>(&iv), cipher);
   }
 
-  inline void generate_chacha8_key(std::string password, chacha8_key& key) {
+  inline void generate_chacha8_key(const void *data, size_t size, chacha8_key& key) {
     static_assert(sizeof(chacha8_key) <= sizeof(hash), "Size of hash must be at least that of chacha8_key");
     char pwd_hash[HASH_SIZE];
-    crypto::cn_slow_hash(password.data(), password.size(), pwd_hash);
+    crypto::cn_slow_hash(data, size, pwd_hash);
     memcpy(&key, pwd_hash, sizeof(key));
     memset(pwd_hash, 0, sizeof(pwd_hash));
+  }
+
+  inline void generate_chacha8_key(std::string password, chacha8_key& key) {
+    return generate_chacha8_key(password.data(), password.size(), key);
   }
 }
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -133,6 +133,17 @@ namespace tools
       END_SERIALIZE()
     };
 
+    struct cache_file_data
+    {
+      crypto::chacha8_iv iv;
+      std::string cache_data;
+
+      BEGIN_SERIALIZE_OBJECT()
+        FIELD(iv)
+        FIELD(cache_data)
+      END_SERIALIZE()
+    };
+
     /*!
      * \brief Generates a wallet or restores one.
      * \param  wallet_        Name of wallet file
@@ -307,6 +318,7 @@ namespace tools
     void add_unconfirmed_tx(const cryptonote::transaction& tx, uint64_t change_amount);
     void generate_genesis(cryptonote::block& b);
     void check_genesis(const crypto::hash& genesis_hash) const; //throws
+    bool generate_chacha8_key_from_secret_keys(crypto::chacha8_key &key) const;
 
     cryptonote::account_base m_account;
     std::string m_daemon_address;


### PR DESCRIPTION
It contains private data, such as a record of transactions.
The key is derived from the view secret key.

The encryption currently is one shot, so may require a lot of
memory for large wallet caches.