### PR TITLE
Fixed a small output bug in print_block - a newline was missing - and…

### DIFF
--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -65,9 +65,11 @@ namespace {
       << "is orphan: " << header.orphan_status << std::endl
       << "height: " << boost::lexical_cast<std::string>(header.height) << std::endl
       << "depth: " << boost::lexical_cast<std::string>(header.depth) << std::endl
-      << "hash: " << header.hash
+      << "hash: " << header.hash << std::endl
+      << "tx tree hash: " << header.tx_tree_hash << std::endl
       << "difficulty: " << boost::lexical_cast<std::string>(header.difficulty) << std::endl
-      << "reward: " << boost::lexical_cast<std::string>(header.reward);
+      << "reward: " << boost::lexical_cast<std::string>(header.reward) << std::endl
+      << "tx count: " << boost::lexical_cast<std::string>(header.txcount);   
   }
 }
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -657,8 +657,11 @@ namespace cryptonote
     responce.height = height;
     responce.depth = m_core.get_current_blockchain_height() - height - 1;
     responce.hash = string_tools::pod_to_hex(hash);
+    responce.tx_tree_hash = string_tools::pod_to_hex(get_tx_tree_hash(blk));
     responce.difficulty = m_core.get_blockchain_storage().block_difficulty(height);
     responce.reward = get_block_reward(blk);
+    tools::write_varint(&responce.txcount, blk.tx_hashes.size());
+    responce.txcount++;		// coinbase tx
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -449,8 +449,10 @@ namespace cryptonote
       uint64_t height;
       uint64_t depth;
       std::string hash;
+      std::string tx_tree_hash;
       difficulty_type difficulty;
       uint64_t reward;
+      uint64_t txcount;
       
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(major_version)
@@ -462,8 +464,10 @@ namespace cryptonote
         KV_SERIALIZE(height)
         KV_SERIALIZE(depth)
         KV_SERIALIZE(hash)
+        KV_SERIALIZE(tx_tree_hash)
         KV_SERIALIZE(difficulty)
         KV_SERIALIZE(reward)
+        KV_SERIALIZE(txcount)
       END_KV_SERIALIZE_MAP()
   };
 


### PR DESCRIPTION
… added the tree hash and number of transactions to print_block.