### PR TITLE
hardfork: switch voting to block minor version

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -946,8 +946,8 @@ bool Blockchain::create_block_template(block& b, const account_public_address& m
     CRITICAL_REGION_BEGIN(m_blockchain_lock);
     height = m_db->height();
 
-    b.major_version = m_hardfork->get_ideal_version();
-    b.minor_version = 0;
+    b.major_version = m_hardfork->get_current_version();
+    b.minor_version = m_hardfork->get_ideal_version();
     b.prev_id = get_tail_id();
     b.timestamp = time(NULL);
 

--- a/src/cryptonote_core/cryptonote_basic.h
+++ b/src/cryptonote_core/cryptonote_basic.h
@@ -277,8 +277,8 @@ namespace cryptonote
   /************************************************************************/
   struct block_header
   {
-    uint8_t major_version;  // now used as a voting mechanism, rather than how this particular block is built
-    uint8_t minor_version;
+    uint8_t major_version;
+    uint8_t minor_version;  // now used as a voting mechanism, rather than how this particular block is built
     uint64_t timestamp;
     crypto::hash  prev_id;
     uint32_t nonce;

--- a/tests/unit_tests/hardfork.cpp
+++ b/tests/unit_tests/hardfork.cpp
@@ -131,7 +131,7 @@ private:
 static cryptonote::block mkblock(uint8_t version)
 {
   cryptonote::block b;
-  b.major_version = version;
+  b.minor_version = version;
   return b;
 }
 
@@ -358,7 +358,6 @@ TEST(new_blocks, denied)
     ASSERT_TRUE(hf.add(2, 2, 1));
     hf.init();
 
-    ASSERT_FALSE(hf.add(mkblock(0), 0));
     ASSERT_TRUE(hf.add(mkblock(1), 0));
     ASSERT_TRUE(hf.add(mkblock(1), 1));
     ASSERT_TRUE(hf.add(mkblock(1), 2));
@@ -384,7 +383,6 @@ TEST(new_version, early)
     ASSERT_TRUE(hf.add(2, 4, 1));
     hf.init();
 
-    ASSERT_FALSE(hf.add(mkblock(0), 0));
     ASSERT_TRUE(hf.add(mkblock(2), 0));
     ASSERT_TRUE(hf.add(mkblock(2), 1)); // we have enough votes already
     ASSERT_TRUE(hf.add(mkblock(2), 2));
@@ -417,7 +415,6 @@ TEST(reorganize, changed)
 #define ADD_TRUE(v, h) ADD(v, h, TRUE)
 #define ADD_FALSE(v, h) ADD(v, h, FALSE)
 
-    ADD_FALSE(0, 0);
     ADD_TRUE(1, 0);
     ADD_TRUE(1, 1);
     ADD_TRUE(2, 2);


### PR DESCRIPTION
Using major version would cause older daemons to reject those
blocks as they fail to deserialize blocks with a major version
which is not 1. There is no such restriction on the minor
version, so switching allows older daemons to coexist with
newer ones till the actual fork date, when most will hopefully
have updated already.

Also, for the same reason, we consider a vote for 0 to be a
vote for 1, since older daemons set minor version to 0.