### PR TITLE
console_handler: silence spurious message when exiting daemon

### DIFF
--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -275,7 +275,7 @@ namespace epee
 
         std::string command;
         bool get_line_ret = m_stdin_reader.get_line(command);
-        if (m_stdin_reader.eos())
+        if (!m_running || m_stdin_reader.eos())
         {
           break;
         }


### PR DESCRIPTION
The daemon registers a custom exit command, which cause the
loop to stop. Catch this case before printing "Failed to read line"
as this is an expected case.