### PR TITLE
Fix leak on real output when using a very recent output

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -45,6 +45,7 @@
 #define CURRENT_BLOCK_MAJOR_VERSION                     1
 #define CURRENT_BLOCK_MINOR_VERSION                     0
 #define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT              60*60*2
+#define CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE             10
 
 #define BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW               60
 

--- a/src/cryptonote_core/blockchain_storage.cpp
+++ b/src/cryptonote_core/blockchain_storage.cpp
@@ -1042,7 +1042,7 @@ size_t blockchain_storage::find_end_of_allowed_index(const std::vector<std::pair
     --i;
     transactions_container::const_iterator it = m_transactions.find(amount_outs[i].first);
     CHECK_AND_ASSERT_MES(it != m_transactions.end(), 0, "internal error: failed to find transaction from outputs index with tx_id=" << amount_outs[i].first);
-    if(it->second.m_keeper_block_height + CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW <= get_current_blockchain_height() )
+    if(it->second.m_keeper_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE <= get_current_blockchain_height() )
       return i+1;
   } while (i != 0);
   return 0;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1073,7 +1073,7 @@ bool wallet2::is_transfer_unlocked(const transfer_details& td) const
   if(!is_tx_spendtime_unlocked(td.m_tx.unlock_time))
     return false;
 
-  if(td.m_block_height + DEFAULT_TX_SPENDABLE_AGE > m_blockchain.size())
+  if(td.m_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE > m_blockchain.size())
     return false;
 
   return true;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -50,7 +50,6 @@
 #include "wallet_errors.h"
 
 #include <iostream>
-#define DEFAULT_TX_SPENDABLE_AGE                               10
 #define WALLET_RCP_CONNECTION_TIMEOUT                          200000
 
 namespace tools


### PR DESCRIPTION
The wallet and the daemon applied different height considerations
when selecting outputs to use. This can leak information on which
input in a ring signature is the real one.

Found and originally fixed by smooth on Aeon.