### PR TITLE
daemon: add a status command

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -75,6 +75,13 @@ bool t_command_parser_executor::show_difficulty(const std::vector<std::string>& 
   return m_executor.show_difficulty();
 }
 
+bool t_command_parser_executor::show_status(const std::vector<std::string>& args)
+{
+  if (!args.empty()) return false;
+
+  return m_executor.show_status();
+}
+
 bool t_command_parser_executor::print_connections(const std::vector<std::string>& args)
 {
   if (!args.empty()) return false;

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -63,6 +63,8 @@ public:
 
   bool show_difficulty(const std::vector<std::string>& args);
 
+  bool show_status(const std::vector<std::string>& args);
+
   bool print_connections(const std::vector<std::string>& args);
 
   bool print_blockchain_info(const std::vector<std::string>& args);

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -135,6 +135,11 @@ t_command_server::t_command_server(
     , "Show difficulty"
     );
   m_command_lookup.set_handler(
+      "status"
+    , std::bind(&t_command_parser_executor::show_status, &m_parser, p::_1)
+    , "Show status"
+    );
+  m_command_lookup.set_handler(
       "stop_daemon"
     , std::bind(&t_command_parser_executor::stop_daemon, &m_parser, p::_1)
     , "Stop the daemon"

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -73,6 +73,8 @@ public:
 
   bool show_difficulty();
 
+  bool show_status();
+
   bool print_connections();
 
   bool print_blockchain_info(uint64_t start_block_index, uint64_t end_block_index);


### PR DESCRIPTION
Displays current block height and target, net hash, hard fork
basic info, and connections.
Useful as a basic user friendly "what's going on here" command.