### PR TITLE
rpc: fix start_mining and status RPC crashes

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -230,6 +230,7 @@ bool t_command_parser_executor::start_mining(const std::vector<std::string>& arg
   }
 
   cryptonote::account_public_address adr;
+  bool testnet = false;
   if(!cryptonote::get_account_address_from_str(adr, false, args.front()))
   {
     if(!cryptonote::get_account_address_from_str(adr, true, args.front()))
@@ -237,6 +238,7 @@ bool t_command_parser_executor::start_mining(const std::vector<std::string>& arg
       std::cout << "target account address has wrong format" << std::endl;
       return true;
     }
+    testnet = true;
     std::cout << "Mining to a testnet address, make sure this is intentional!" << std::endl;
   }
   uint64_t threads_count = 1;
@@ -250,7 +252,7 @@ bool t_command_parser_executor::start_mining(const std::vector<std::string>& arg
     threads_count = (ok && 0 < threads_count) ? threads_count : 1;
   }
 
-  m_executor.start_mining(adr, threads_count);
+  m_executor.start_mining(adr, threads_count, testnet);
 
   return true;
 }

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -262,7 +262,7 @@ bool t_rpc_command_executor::show_status() {
     {
       return true;
     }
-    if (!m_rpc_client->rpc_request(hfreq, hfres, "/hard_fork_info", fail_message.c_str()))
+    if (!m_rpc_client->json_rpc_request(hfreq, hfres, "hard_fork_info", fail_message.c_str()))
     {
       return true;
     }
@@ -285,7 +285,7 @@ bool t_rpc_command_executor::show_status() {
     % (unsigned long long)ires.height
     % (unsigned long long)(ires.target_height ? ires.target_height : ires.height)
     % (100.0f * ires.height / (ires.target_height ? ires.target_height < ires.height ? ires.height : ires.target_height : ires.height))
-    % (m_rpc_server->is_testnet() ? "testnet" : "mainnet")
+    % (ires.testnet ? "testnet" : "mainnet")
     % [&ires]()->std::string {
       float hr = ires.difficulty / 60.0f;
       if (hr>1e9) return (boost::format("%.2f GH/s") % (hr/1e9)).str();
@@ -733,10 +733,10 @@ bool t_rpc_command_executor::print_transaction_pool_short() {
   return true;
 }
 
-bool t_rpc_command_executor::start_mining(cryptonote::account_public_address address, uint64_t num_threads) {
+bool t_rpc_command_executor::start_mining(cryptonote::account_public_address address, uint64_t num_threads, bool testnet) {
   cryptonote::COMMAND_RPC_START_MINING::request req;
   cryptonote::COMMAND_RPC_START_MINING::response res;
-  req.miner_address = cryptonote::get_account_address_as_str(m_rpc_server->is_testnet(), address);
+  req.miner_address = cryptonote::get_account_address_as_str(testnet, address);
   req.threads_count = num_threads;
 
   std::string fail_message = "Mining did not start";

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -95,7 +95,7 @@ public:
 
   bool print_transaction_pool_short();
 
-  bool start_mining(cryptonote::account_public_address address, uint64_t num_threads);
+  bool start_mining(cryptonote::account_public_address address, uint64_t num_threads, bool testnet);
 
   bool stop_mining();
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -127,6 +127,7 @@ namespace cryptonote
     res.incoming_connections_count = total_conn - res.outgoing_connections_count;
     res.white_peerlist_size = m_p2p.get_peerlist_manager().get_white_peers_count();
     res.grey_peerlist_size = m_p2p.get_peerlist_manager().get_gray_peers_count();
+    res.testnet = m_testnet;
     res.status = CORE_RPC_STATUS_OK;
     return true;
   }

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -280,6 +280,7 @@ namespace cryptonote
       uint64_t incoming_connections_count;
       uint64_t white_peerlist_size;
       uint64_t grey_peerlist_size;
+      bool testnet;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(status)
@@ -293,6 +294,7 @@ namespace cryptonote
         KV_SERIALIZE(incoming_connections_count)
         KV_SERIALIZE(white_peerlist_size)
         KV_SERIALIZE(grey_peerlist_size)
+        KV_SERIALIZE(testnet)
       END_KV_SERIALIZE_MAP()
     };
   };


### PR DESCRIPTION
They check whether they're running on testnet by accessing the
m_rpc_server object, which does not exist when in RPC mode.

Also, fix hard_fork_info being called with the wrong API.