### PR TITLE
simplewallet: add a set default-mixin command

### DIFF
--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -100,6 +100,7 @@ namespace cryptonote
     bool seed_set_language(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_always_confirm_transfers(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_store_tx_keys(const std::vector<std::string> &args = std::vector<std::string>());
+    bool set_default_mixin(const std::vector<std::string> &args = std::vector<std::string>());
     bool help(const std::vector<std::string> &args = std::vector<std::string>());
     bool start_mining(const std::vector<std::string> &args);
     bool stop_mining(const std::vector<std::string> &args);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -543,6 +543,9 @@ bool wallet2::store_keys(const std::string& keys_file_name, const std::string& p
   value2.SetInt(m_store_tx_keys ? 1 :0);
   json.AddMember("store_tx_keys", value2, json.GetAllocator());
 
+  value2.SetUint(m_default_mixin);
+  json.AddMember("default_mixin", value2, json.GetAllocator());
+
   // Serialize the JSON object
   rapidjson::StringBuffer buffer;
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
@@ -604,6 +607,7 @@ void wallet2::load_keys(const std::string& keys_file_name, const std::string& pa
     is_old_file_format = true;
     m_watch_only = false;
     m_always_confirm_transfers = false;
+    m_default_mixin = 0;
   }
   else
   {
@@ -624,6 +628,7 @@ void wallet2::load_keys(const std::string& keys_file_name, const std::string& pa
     }
     m_always_confirm_transfers = json.HasMember("always_confirm_transfers") && (json["always_confirm_transfers"].GetInt() != 0);
     m_store_tx_keys = json.HasMember("store_tx_keys") && (json["store_tx_keys"].GetInt() != 0);
+    m_default_mixin = json.HasMember("default_mixin") ? json["default_mixin"].GetUint() : 0;
   }
 
   const cryptonote::account_keys& keys = m_account.get_keys();

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -79,9 +79,9 @@ namespace tools
 
   class wallet2
   {
-    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers (false), m_store_tx_keys(false) {};
+    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers (false), m_store_tx_keys(false), m_default_mixin(0) {}
   public:
-    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_restricted(restricted), is_old_file_format(false), m_store_tx_keys(false) {};
+    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_restricted(restricted), is_old_file_format(false), m_store_tx_keys(false), m_default_mixin(0) {}
     struct transfer_details
     {
       uint64_t m_block_height;
@@ -293,6 +293,8 @@ namespace tools
     void always_confirm_transfers(bool always) { m_always_confirm_transfers = always; }
     bool store_tx_keys() const { return m_store_tx_keys; }
     void store_tx_keys(bool store) { m_store_tx_keys = store; }
+    uint32_t default_mixin() const { return m_default_mixin; }
+    void default_mixin(uint32_t m) { m_default_mixin = m; }
 
     bool get_tx_key(const crypto::hash &txid, crypto::secret_key &tx_key) const;
 
@@ -353,6 +355,7 @@ namespace tools
     bool m_watch_only; /*!< no spend key */
     bool m_always_confirm_transfers;
     bool m_store_tx_keys; /*!< request txkey to be returned in RPC, and store in the wallet cache file */
+    uint32_t m_default_mixin;
   };
 }
 BOOST_CLASS_VERSION(tools::wallet2, 8)


### PR DESCRIPTION
The default default mixin is 4. It can now be changed per wallet.