### PR TITLE
simplewallet: add a set default-mixin command

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -366,6 +366,62 @@ bool simple_wallet::set_store_tx_keys(const std::vector<std::string> &args/* = s
   return true;
 }
 
+bool simple_wallet::set_default_mixin(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
+{
+  bool success = false;
+  if (m_wallet->watch_only())
+  {
+    fail_msg_writer() << tr("This wallet is watch-only and cannot transfer.");
+    return true;
+  }
+  try
+  {
+    if (strchr(args[1].c_str(), '-'))
+    {
+      fail_msg_writer() << tr("Error: mixin must be an integer greater or equal to 2");
+      return true;
+    }
+    uint32_t mixin = boost::lexical_cast<uint32_t>(args[1]);
+    if (mixin < 2 && mixin != 0)
+    {
+      fail_msg_writer() << tr("Error: mixin must be an integer greater or equal to 2");
+      return true;
+    }
+    if (mixin == 0)
+      mixin = DEFAULT_MIX;
+
+    tools::password_container pwd_container;
+    success = pwd_container.read_password();
+    if (!success)
+    {
+      fail_msg_writer() << tr("failed to read wallet password");
+      return true;
+    }
+
+    /* verify password before using so user doesn't accidentally set a new password for rewritten wallet */
+    success = m_wallet->verify_password(pwd_container.password());
+    if (!success)
+    {
+      fail_msg_writer() << tr("invalid password");
+      return true;
+    }
+
+    m_wallet->default_mixin(mixin);
+    m_wallet->rewrite(m_wallet_file, pwd_container.password());
+    return true;
+  }
+  catch(const boost::bad_lexical_cast &)
+  {
+    fail_msg_writer() << tr("Error: mixin must be an integer greater or equal to 2");
+    return true;
+  }
+  catch(...)
+  {
+    fail_msg_writer() << tr("Error changing default mixin");
+    return true;
+  }
+}
+
 bool simple_wallet::help(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
   success_msg_writer() << get_commands_str();
@@ -395,7 +451,7 @@ simple_wallet::simple_wallet()
   m_cmd_binder.set_handler("viewkey", boost::bind(&simple_wallet::viewkey, this, _1), tr("Get viewkey"));
   m_cmd_binder.set_handler("spendkey", boost::bind(&simple_wallet::spendkey, this, _1), tr("Get spendkey"));
   m_cmd_binder.set_handler("seed", boost::bind(&simple_wallet::seed, this, _1), tr("Get deterministic seed"));
-  m_cmd_binder.set_handler("set", boost::bind(&simple_wallet::set_variable, this, _1), tr("available options: seed language - Set wallet seed langage; always-confirm-transfers <1|0> - whether to confirm unsplit txes; store-tx-keys <1|0> - whether to store per-tx private keys for future reference"));
+  m_cmd_binder.set_handler("set", boost::bind(&simple_wallet::set_variable, this, _1), tr("available options: seed language - Set wallet seed langage; always-confirm-transfers <1|0> - whether to confirm unsplit txes; store-tx-keys <1|0> - whether to store per-tx private keys for future reference; default_mixin <n> - set default mixin (default default is 4"));
   m_cmd_binder.set_handler("rescan_spent", boost::bind(&simple_wallet::rescan_spent, this, _1), tr("Rescan blockchain for spent outputs"));
   m_cmd_binder.set_handler("get_tx_key", boost::bind(&simple_wallet::get_tx_key, this, _1), tr("Get transaction key (r) for a given tx"));
   m_cmd_binder.set_handler("check_tx_key", boost::bind(&simple_wallet::check_tx_key, this, _1), tr("Check amount going to a given address in a partcular tx"));
@@ -406,7 +462,7 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
 {
   if (args.empty())
   {
-    fail_msg_writer() << tr("set: needs an argument. available options: seed, always-confirm-transfers");
+    fail_msg_writer() << tr("set: needs an argument. available options: seed, always-confirm-transfers, default-mixin");
     return true;
   }
   else
@@ -453,6 +509,21 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
         std::vector<std::string> local_args = args;
         local_args.erase(local_args.begin(), local_args.begin()+2);
         set_store_tx_keys(local_args);
+        return true;
+      }
+    }
+    else if (args[0] == "default-mixin")
+    {
+      if (args.size() <= 1)
+      {
+        fail_msg_writer() << tr("set default-mixin: needs an argument (integer greater of equal to 2)");
+        return true;
+      }
+      else
+      {
+        std::vector<std::string> local_args = args;
+        local_args.erase(local_args.begin(), local_args.begin()+2);
+        set_default_mixin(local_args);
         return true;
       }
     }
@@ -1382,7 +1453,9 @@ bool simple_wallet::transfer_main(bool new_algorithm, const std::vector<std::str
   if(local_args.size() > 0) {
     if(!epee::string_tools::get_xtype_from_string(fake_outs_count, local_args[0]))
     {
-      fake_outs_count = DEFAULT_MIX;
+      fake_outs_count = m_wallet->default_mixin();
+      if (fake_outs_count == 0)
+        fake_outs_count = DEFAULT_MIX;
     }
     else
     {

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -100,6 +100,7 @@ namespace cryptonote
     bool seed_set_language(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_always_confirm_transfers(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_store_tx_keys(const std::vector<std::string> &args = std::vector<std::string>());
+    bool set_default_mixin(const std::vector<std::string> &args = std::vector<std::string>());
     bool help(const std::vector<std::string> &args = std::vector<std::string>());
     bool start_mining(const std::vector<std::string> &args);
     bool stop_mining(const std::vector<std::string> &args);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -599,6 +599,9 @@ bool wallet2::store_keys(const std::string& keys_file_name, const std::string& p
   value2.SetInt(m_store_tx_keys ? 1 :0);
   json.AddMember("store_tx_keys", value2, json.GetAllocator());
 
+  value2.SetUint(m_default_mixin);
+  json.AddMember("default_mixin", value2, json.GetAllocator());
+
   // Serialize the JSON object
   rapidjson::StringBuffer buffer;
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
@@ -660,6 +663,7 @@ void wallet2::load_keys(const std::string& keys_file_name, const std::string& pa
     is_old_file_format = true;
     m_watch_only = false;
     m_always_confirm_transfers = false;
+    m_default_mixin = 0;
   }
   else
   {
@@ -680,6 +684,7 @@ void wallet2::load_keys(const std::string& keys_file_name, const std::string& pa
     }
     m_always_confirm_transfers = json.HasMember("always_confirm_transfers") && (json["always_confirm_transfers"].GetInt() != 0);
     m_store_tx_keys = json.HasMember("store_tx_keys") && (json["store_tx_keys"].GetInt() != 0);
+    m_default_mixin = json.HasMember("default_mixin") ? json["default_mixin"].GetUint() : 0;
   }
 
   const cryptonote::account_keys& keys = m_account.get_keys();

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -80,9 +80,9 @@ namespace tools
 
   class wallet2
   {
-    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers (false), m_store_tx_keys(false) {};
+    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers (false), m_store_tx_keys(false), m_default_mixin(0) {}
   public:
-    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_restricted(restricted), is_old_file_format(false), m_store_tx_keys(false) {
+    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_restricted(restricted), is_old_file_format(false), m_store_tx_keys(false), m_default_mixin(0) {
       ipc_client = NULL;
       connect_to_daemon();
       if (!ipc_client) {
@@ -313,6 +313,8 @@ namespace tools
     void always_confirm_transfers(bool always) { m_always_confirm_transfers = always; }
     bool store_tx_keys() const { return m_store_tx_keys; }
     void store_tx_keys(bool store) { m_store_tx_keys = store; }
+    uint32_t default_mixin() const { return m_default_mixin; }
+    void default_mixin(uint32_t m) { m_default_mixin = m; }
 
     bool get_tx_key(const crypto::hash &txid, crypto::secret_key &tx_key) const;
 
@@ -376,6 +378,7 @@ namespace tools
     bool m_watch_only; /*!< no spend key */
     bool m_always_confirm_transfers;
     bool m_store_tx_keys; /*!< request txkey to be returned in RPC, and store in the wallet cache file */
+    uint32_t m_default_mixin;
   };
 }
 BOOST_CLASS_VERSION(tools::wallet2, 8)


### PR DESCRIPTION
The default default mixin is 4. It can now be changed per wallet.