### PR TITLE
Revert "db_bdb: record numbers for recno databases start at 1"

### DIFF
--- a/src/blockchain_db/berkeleydb/db_bdb.cpp
+++ b/src/blockchain_db/berkeleydb/db_bdb.cpp
@@ -1516,7 +1516,7 @@ output_data_t BlockchainBDB::get_output_key(const uint64_t& global_index) const
     LOG_PRINT_L3("BlockchainBDB::" << __func__);
     check_open();
 
-    Dbt_copy<uint32_t> k(global_index + 1);
+    Dbt_copy<uint32_t> k(global_index);
     Dbt_copy<output_data_t> v;
     auto get_result = m_output_keys->get(DB_DEFAULT_TX, &k, &v, 0);
     if (get_result == DB_NOTFOUND)
@@ -1652,7 +1652,7 @@ tx_out_index BlockchainBDB::get_output_tx_and_index_from_global(const uint64_t& 
     LOG_PRINT_L3("BlockchainBDB::" << __func__);
     check_open();
 
-    Dbt_copy<uint32_t> k(index + 1);
+    Dbt_copy<uint32_t> k(index);
     Dbt_copy<crypto::hash > v;
 
     auto get_result = m_output_txs->get(DB_DEFAULT_TX, &k, &v, 0);
@@ -2011,7 +2011,7 @@ void BlockchainBDB::get_output_key(const uint64_t &amount, const std::vector<uin
     {
         for (const uint64_t &index : global_indices)
         {
-            Dbt_copy<uint32_t> k(index + 1);
+            Dbt_copy<uint32_t> k(index);
             Dbt_copy<output_data_t> v;
 
             auto get_result = m_output_keys->get(DB_DEFAULT_TX, &k, &v, 0);


### PR DESCRIPTION
It looks like some of the indices passed to the DB access functions
are already bumped by 1. Moreover, the existing code was not
throwing DB errors with 0 keys, and this is unlikely if it really
was using 0 keys. Last, this patch broke sync from scratch in at
least one case. So I'm calling it bad and reverting it.

This reverts commit bfc97401ae81bb30278a318de7f048c653bf6582.