### PR TITLE
wallet: track outgoing payments and add a show_transfers command

### DIFF
--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -126,6 +126,7 @@ namespace cryptonote
     bool set_log(const std::vector<std::string> &args);
     bool get_tx_key(const std::vector<std::string> &args);
     bool check_tx_key(const std::vector<std::string> &args);
+    bool show_transfers(const std::vector<std::string> &args);
 
     uint64_t get_daemon_blockchain_height(std::string& err);
     bool try_connect_to_daemon();


### PR DESCRIPTION
It's a user friendly display of incoming and outgoing transfers,
listed by height, within an optional height range.