### PR TITLE
Relay transactions when they linger too long in the pool

### DIFF
--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -401,7 +401,7 @@ int import_from_file(FakeCore& simple_core, const std::string& import_file_path,
             // get_transaction_hash(tx, hsh, blob_size);
             tx_verification_context tvc = AUTO_VAL_INIT(tvc);
             bool r = true;
-            r = simple_core.m_pool.add_tx(tx, tvc, true);
+            r = simple_core.m_pool.add_tx(tx, tvc, true, true);
             if (!r)
             {
               LOG_PRINT_RED_L0("failed to add transaction to transaction pool, height=" << h <<", tx_num=" << tx_num);

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -410,7 +410,12 @@ block Blockchain::pop_block_from_blockchain()
         if (!is_coinbase(tx))
         {
             cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);
-            bool r = m_tx_pool.add_tx(tx, tvc, true);
+            // We assume that if they were in a block, the transactions are already
+            // known to the network as a whole. However, if we had mined that block,
+            // that might not be always true. Unlikely though, and always relaying
+            // these again might cause a spike of traffic as many nodes re-relay
+            // all the transactions in a popped block when a reorg happens.
+            bool r = m_tx_pool.add_tx(tx, tvc, true, true);
             if (!r)
             {
                 LOG_ERROR("Error returning transaction to tx_pool");
@@ -2460,6 +2465,7 @@ bool Blockchain::handle_block_to_main_chain(const block& bl, const crypto::hash&
         transaction tx;
         size_t blob_size = 0;
         uint64_t fee = 0;
+        bool relayed = false;
         TIME_MEASURE_START(aa);
 
 // XXX old code does not check whether tx exists
@@ -2475,7 +2481,7 @@ bool Blockchain::handle_block_to_main_chain(const block& bl, const crypto::hash&
         TIME_MEASURE_START(bb);
 
         // get transaction with hash <tx_id> from tx_pool
-        if(!m_tx_pool.take_tx(tx_id, tx, blob_size, fee))
+        if(!m_tx_pool.take_tx(tx_id, tx, blob_size, fee, relayed))
         {
             LOG_PRINT_L1("Block with id: " << id  << " has at least one unknown transaction with id: " << tx_id);
             bvc.m_verifivation_failed = true;
@@ -2598,7 +2604,12 @@ bool Blockchain::handle_block_to_main_chain(const block& bl, const crypto::hash&
         for (auto& tx : txs)
         {
             cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);
-            if (!m_tx_pool.add_tx(tx, tvc, true))
+            // We assume that if they were in a block, the transactions are already
+            // known to the network as a whole. However, if we had mined that block,
+            // that might not be always true. Unlikely though, and always relaying
+            // these again might cause a spike of traffic as many nodes re-relay
+            // all the transactions in a popped block when a reorg happens.
+            if (!m_tx_pool.add_tx(tx, tvc, true, true))
             {
                 LOG_PRINT_L0("Failed to return taken transaction with hash: " << get_transaction_hash(tx) << " to tx_pool");
             }
@@ -3194,10 +3205,11 @@ void Blockchain::load_compiled_in_block_hashes(bool testnet)
                 size_t blob_size;
                 uint64_t fee;
                 transaction pool_tx;
+                bool relayed;
                 for(const transaction &tx : txs)
                 {
                     crypto::hash tx_hash = get_transaction_hash(tx);
-                    m_tx_pool.take_tx(tx_hash, pool_tx, blob_size, fee);
+                    m_tx_pool.take_tx(tx_hash, pool_tx, blob_size, fee, relayed);
                 }
             }
         }

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -401,7 +401,7 @@ namespace cryptonote
 	  return false;
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::handle_incoming_tx(const blobdata& tx_blob, tx_verification_context& tvc, bool keeped_by_block)
+  bool core::handle_incoming_tx(const blobdata& tx_blob, tx_verification_context& tvc, bool keeped_by_block, bool relayed)
   {
     tvc = boost::value_initialized<tx_verification_context>();
     //want to process all transactions sequentially
@@ -440,7 +440,7 @@ namespace cryptonote
       return false;
     }
 
-    bool r = add_new_tx(tx, tx_hash, tx_prefixt_hash, tx_blob.size(), tvc, keeped_by_block);
+    bool r = add_new_tx(tx, tx_hash, tx_prefixt_hash, tx_blob.size(), tvc, keeped_by_block, relayed);
     if(tvc.m_verifivation_failed)
     {LOG_PRINT_RED_L1("Transaction verification failed: " << tx_hash);}
     else if(tvc.m_verifivation_impossible)
@@ -542,13 +542,13 @@ namespace cryptonote
     return true;
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::add_new_tx(const transaction& tx, tx_verification_context& tvc, bool keeped_by_block)
+  bool core::add_new_tx(const transaction& tx, tx_verification_context& tvc, bool keeped_by_block, bool relayed)
   {
     crypto::hash tx_hash = get_transaction_hash(tx);
     crypto::hash tx_prefix_hash = get_transaction_prefix_hash(tx);
     blobdata bl;
     t_serializable_object_to_blob(tx, bl);
-    return add_new_tx(tx, tx_hash, tx_prefix_hash, bl.size(), tvc, keeped_by_block);
+    return add_new_tx(tx, tx_hash, tx_prefix_hash, bl.size(), tvc, keeped_by_block, relayed);
   }
   //-----------------------------------------------------------------------------------------------
   size_t core::get_blockchain_total_transactions() const
@@ -556,7 +556,7 @@ namespace cryptonote
     return m_blockchain_storage.get_total_transactions();
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::add_new_tx(const transaction& tx, const crypto::hash& tx_hash, const crypto::hash& tx_prefix_hash, size_t blob_size, tx_verification_context& tvc, bool keeped_by_block)
+  bool core::add_new_tx(const transaction& tx, const crypto::hash& tx_hash, const crypto::hash& tx_prefix_hash, size_t blob_size, tx_verification_context& tvc, bool keeped_by_block, bool relayed)
   {
     if(m_mempool.have_tx(tx_hash))
     {
@@ -570,7 +570,28 @@ namespace cryptonote
       return true;
     }
 
-    return m_mempool.add_tx(tx, tx_hash, blob_size, tvc, keeped_by_block);
+    return m_mempool.add_tx(tx, tx_hash, blob_size, tvc, keeped_by_block, relayed);
+  }
+  //-----------------------------------------------------------------------------------------------
+  bool core::relay_txpool_transactions()
+  {
+    // we attempt to relay txes that should be relayed, but were not
+    std::list<std::pair<crypto::hash, cryptonote::transaction>> txs;
+    if (m_mempool.get_relayable_transactions(txs))
+    {
+      cryptonote_connection_context fake_context = AUTO_VAL_INIT(fake_context);
+      tx_verification_context tvc = AUTO_VAL_INIT(tvc);
+      NOTIFY_NEW_TRANSACTIONS::request r;
+      blobdata bl;
+      for (auto it = txs.begin(); it != txs.end(); ++it)
+      {
+        t_serializable_object_to_blob(it->second, bl);
+        r.txs.push_back(bl);
+      }
+      get_protocol()->relay_transactions(r, fake_context);
+      m_mempool.set_relayed(txs);
+    }
+    return true;
   }
   //-----------------------------------------------------------------------------------------------
   bool core::get_block_template(block& b, const account_public_address& adr, difficulty_type& diffic, uint64_t& height, const blobdata& ex_nonce)
@@ -818,6 +839,7 @@ namespace cryptonote
     m_store_blockchain_interval.do_call(boost::bind(&blockchain_storage::store_blockchain, &m_blockchain_storage));
 #endif
     m_fork_moaner.do_call(boost::bind(&core::check_fork_time, this));
+    m_txpool_auto_relayer.do_call(boost::bind(&core::relay_txpool_transactions, this));
     m_miner.on_idle();
     m_mempool.on_idle();
     return true;

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -102,10 +102,11 @@ namespace cryptonote
       * @param tx_blob the tx to handle
       * @param tvc metadata about the transaction's validity
       * @param keeped_by_block if the transaction has been in a block
+      * @param relayed whether the tx was already relayed from a peer
       *
       * @return true if the transaction made it to the transaction pool, otherwise false
       */
-     bool handle_incoming_tx(const blobdata& tx_blob, tx_verification_context& tvc, bool keeped_by_block);
+     bool handle_incoming_tx(const blobdata& tx_blob, tx_verification_context& tvc, bool keeped_by_block, bool relayed);
 
      /**
       * @brief handles an incoming block
@@ -603,9 +604,10 @@ namespace cryptonote
       * @param tx_hash the transaction's hash
       * @param tx_prefix_hash the transaction prefix' hash
       * @param blob_size the size of the transaction
+      * @param relayed whether the tx was relayed
       *
       */
-     bool add_new_tx(const transaction& tx, const crypto::hash& tx_hash, const crypto::hash& tx_prefix_hash, size_t blob_size, tx_verification_context& tvc, bool keeped_by_block);
+     bool add_new_tx(const transaction& tx, const crypto::hash& tx_hash, const crypto::hash& tx_prefix_hash, size_t blob_size, tx_verification_context& tvc, bool keeped_by_block, bool relayed);
 
      /**
       * @brief add a new transaction to the transaction pool
@@ -615,12 +617,13 @@ namespace cryptonote
       * @param tx the transaction to add
       * @param tvc return-by-reference metadata about the transaction's verification process
       * @param keeped_by_block whether or not the transaction has been in a block
+      * @param relayed whether or not the transaction was relayed
       *
       * @return true if the transaction is already in the transaction pool,
       * is already in a block on the Blockchain, or is successfully added
       * to the transaction pool
       */
-     bool add_new_tx(const transaction& tx, tx_verification_context& tvc, bool keeped_by_block);
+     bool add_new_tx(const transaction& tx, tx_verification_context& tvc, bool keeped_by_block, bool relayed);
 
      /**
       * @copydoc Blockchain::add_new_block
@@ -714,6 +717,13 @@ namespace cryptonote
       */
      bool check_fork_time();
 
+     /**
+      * @brief relay an arbitrary set of transactions from the txpool
+      *
+      * @return true
+      */
+     bool relay_txpool_transactions();
+
      static std::atomic<bool> m_fast_exit; //!< whether or not to deinit Blockchain on exit
 
      bool m_test_drop_download = true; //!< whether or not to drop incoming blocks (for testing)
@@ -741,6 +751,7 @@ namespace cryptonote
 
      epee::math_helper::once_a_time_seconds<60*60*12, false> m_store_blockchain_interval; //!< interval for manual storing of Blockchain, if enabled
      epee::math_helper::once_a_time_seconds<60*60*2, false> m_fork_moaner; //!< interval for checking HardFork status
+     epee::math_helper::once_a_time_seconds<60*2, false> m_txpool_auto_relayer; //!< interval for checking re-relaying txpool transactions
 
      std::atomic<bool> m_starter_message_showed; //!< has the "daemon will sync now" message been shown?
 

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -321,7 +321,7 @@ namespace cryptonote
     for(auto tx_blob_it = arg.b.txs.begin(); tx_blob_it!=arg.b.txs.end();tx_blob_it++)
     {
       cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);
-      m_core.handle_incoming_tx(*tx_blob_it, tvc, true);
+      m_core.handle_incoming_tx(*tx_blob_it, tvc, true, true);
       if(tvc.m_verifivation_failed)
       {
         LOG_PRINT_CCONTEXT_L1("Block verification failed: transaction verification failed, dropping connection");
@@ -369,7 +369,7 @@ namespace cryptonote
     for(auto tx_blob_it = arg.txs.begin(); tx_blob_it!=arg.txs.end();)
     {
       cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);
-      m_core.handle_incoming_tx(*tx_blob_it, tvc, false);
+      m_core.handle_incoming_tx(*tx_blob_it, tvc, false, true);
       if(tvc.m_verifivation_failed)
       {
         LOG_PRINT_CCONTEXT_L1("Tx verification failed, dropping connection");
@@ -548,7 +548,7 @@ namespace cryptonote
 			BOOST_FOREACH(auto& tx_blob, block_entry.txs)
 			{
 			  tx_verification_context tvc = AUTO_VAL_INIT(tvc);
-			  m_core.handle_incoming_tx(tx_blob, tvc, true);
+			  m_core.handle_incoming_tx(tx_blob, tvc, true, true);
 			  if(tvc.m_verifivation_failed)
 			  {
 				LOG_ERROR_CCONTEXT("transaction verification failed on NOTIFY_RESPONSE_GET_OBJECTS, \r\ntx_id = " 

--- a/src/ipc/daemon_ipc_handlers.cpp
+++ b/src/ipc/daemon_ipc_handlers.cpp
@@ -298,7 +298,7 @@ namespace IPC
 
       cryptonote::cryptonote_connection_context fake_context = AUTO_VAL_INIT(fake_context);
       cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);
-      if (!core->handle_incoming_tx(tx_blob, tvc, false))
+      if (!core->handle_incoming_tx(tx_blob, tvc, false, false))
       {
         LOG_PRINT_L0("[on_send_raw_tx]: Failed to process tx");
         wap_proto_set_status(message, STATUS_INVALID_TX);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -313,7 +313,7 @@ namespace cryptonote
 
     cryptonote_connection_context fake_context = AUTO_VAL_INIT(fake_context);
     tx_verification_context tvc = AUTO_VAL_INIT(tvc);
-    if(!m_core.handle_incoming_tx(tx_blob, tvc, false))
+    if(!m_core.handle_incoming_tx(tx_blob, tvc, false, false))
     {
       LOG_PRINT_L0("[on_send_raw_tx]: Failed to process tx");
       res.status = "Failed";

--- a/tests/core_proxy/core_proxy.cpp
+++ b/tests/core_proxy/core_proxy.cpp
@@ -167,7 +167,7 @@ string tx2str(const cryptonote::transaction& tx, const cryptonote::hash256& tx_h
     return ss.str();
 }*/
 
-bool tests::proxy_core::handle_incoming_tx(const cryptonote::blobdata& tx_blob, cryptonote::tx_verification_context& tvc, bool keeped_by_block) {
+bool tests::proxy_core::handle_incoming_tx(const cryptonote::blobdata& tx_blob, cryptonote::tx_verification_context& tvc, bool keeped_by_block, bool relayed) {
     if (!keeped_by_block)
         return true;
 

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -75,7 +75,7 @@ namespace tests
     bool get_stat_info(cryptonote::core_stat_info& st_inf){return true;}
     bool have_block(const crypto::hash& id);
     bool get_blockchain_top(uint64_t& height, crypto::hash& top_id);
-    bool handle_incoming_tx(const cryptonote::blobdata& tx_blob, cryptonote::tx_verification_context& tvc, bool keeped_by_block);
+    bool handle_incoming_tx(const cryptonote::blobdata& tx_blob, cryptonote::tx_verification_context& tvc, bool keeped_by_block, bool relaued);
     bool handle_incoming_block(const cryptonote::blobdata& block_blob, cryptonote::block_verification_context& bvc, bool update_miner_blocktemplate = true);
     void pause_mine(){}
     void resume_mine(){}

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -364,7 +364,7 @@ public:
 
     cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);
     size_t pool_size = m_c.get_pool_transactions_count();
-    m_c.handle_incoming_tx(t_serializable_object_to_blob(tx), tvc, m_txs_keeped_by_block);
+    m_c.handle_incoming_tx(t_serializable_object_to_blob(tx), tvc, m_txs_keeped_by_block, false);
     bool tx_added = pool_size + 1 == m_c.get_pool_transactions_count();
     bool r = check_tx_verification_context(tvc, tx_added, m_ev_index, tx, m_validator);
     CHECK_AND_NO_ASSERT_MES(r, false, "tx verification context check failed");
@@ -421,7 +421,7 @@ public:
 
     cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);
     size_t pool_size = m_c.get_pool_transactions_count();
-    m_c.handle_incoming_tx(sr_tx.data, tvc, m_txs_keeped_by_block);
+    m_c.handle_incoming_tx(sr_tx.data, tvc, m_txs_keeped_by_block, false);
     bool tx_added = pool_size + 1 == m_c.get_pool_transactions_count();
 
     cryptonote::transaction tx;


### PR DESCRIPTION
The last relayed time of a transaction is maintained, and
transactions will be relayed again if they are still in the
pool after a certain amount of time, which increases with
the transaction's age. All such transactions are resent,
whether or not they originated on the local node.