### PR TITLE
rpc: pass current block target in rpc

### DIFF
--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -242,7 +242,7 @@ bool t_rpc_command_executor::show_difficulty() {
 
   tools::success_msg_writer() <<   "BH: " << res.height
                               << ", DIFF: " << res.difficulty
-                              << ", HR: " << (int) res.difficulty / 60L << " H/s";
+                              << ", HR: " << (int) res.difficulty / res.target << " H/s";
 
   return true;
 }
@@ -287,7 +287,7 @@ bool t_rpc_command_executor::show_status() {
     % (100.0f * ires.height / (ires.target_height ? ires.target_height < ires.height ? ires.height : ires.target_height : ires.height))
     % (ires.testnet ? "testnet" : "mainnet")
     % [&ires]()->std::string {
-      float hr = ires.difficulty / 60.0f;
+      float hr = ires.difficulty / ires.target;
       if (hr>1e9) return (boost::format("%.2f GH/s") % (hr/1e9)).str();
       if (hr>1e6) return (boost::format("%.2f MH/s") % (hr/1e6)).str();
       if (hr>1e3) return (boost::format("%.2f kH/s") % (hr/1e3)).str();

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -119,6 +119,7 @@ namespace cryptonote
     res.height = m_core.get_current_blockchain_height();
     res.target_height = m_core.get_target_blockchain_height();
     res.difficulty = m_core.get_blockchain_storage().get_difficulty_for_next_block();
+    res.target = m_core.get_blockchain_storage().get_current_hard_fork_version() < 2 ? DIFFICULTY_TARGET_V1 : DIFFICULTY_TARGET;
     res.tx_count = m_core.get_blockchain_storage().get_total_transactions() - res.height; //without coinbase
     res.tx_pool_size = m_core.get_pool_transactions_count();
     res.alt_blocks_count = m_core.get_blockchain_storage().get_alternative_blocks_count();

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -273,6 +273,7 @@ namespace cryptonote
       uint64_t height;
       uint64_t target_height;
       uint64_t difficulty;
+      uint64_t target;
       uint64_t tx_count;
       uint64_t tx_pool_size;
       uint64_t alt_blocks_count;


### PR DESCRIPTION
This fixes the hash rate being wrong on testnet after the switch
to 2 minute blocks