### PR TITLE
core: serialize block major/minor versions as bytes, not varints

### DIFF
--- a/src/cryptonote_core/cryptonote_basic.h
+++ b/src/cryptonote_core/cryptonote_basic.h
@@ -284,8 +284,8 @@ namespace cryptonote
     uint32_t nonce;
 
     BEGIN_SERIALIZE()
-      VARINT_FIELD(major_version)
-      VARINT_FIELD(minor_version)
+      FIELD(major_version)
+      FIELD(minor_version)
       VARINT_FIELD(timestamp)
       FIELD(prev_id)
       FIELD(nonce)


### PR DESCRIPTION
This allows them to be saved as a fixed (one byte) chunk whatever
the value. Using a varint will use two bytes as the high bit gets
set.

This is backward compatible with current usage (0-2 values).