### PR TITLE
wallet: optional automatic refresh from the daemon

### DIFF
--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -251,27 +251,33 @@ namespace epee
       m_stdin_reader.stop();
     }
 
+    void print_prompt()
+    {
+      if (!m_prompt.empty())
+      {
+        epee::log_space::set_console_color(epee::log_space::console_color_yellow, true);
+        std::cout << m_prompt;
+        if (' ' != m_prompt.back())
+          std::cout << ' ';
+        epee::log_space::reset_console_color();
+        std::cout.flush();
+      }
+    }
+
   private:
     template<typename t_cmd_handler>
     bool run(const std::string& prompt, const std::string& usage, const t_cmd_handler& cmd_handler, std::function<void(void)> exit_handler)
     {
       TRY_ENTRY();
       bool continue_handle = true;
+      m_prompt = prompt;
       while(continue_handle)
       {
         if (!m_running)
         {
           break;
         }
-        if (!prompt.empty())
-        {
-          epee::log_space::set_console_color(epee::log_space::console_color_yellow, true);
-          std::cout << prompt;
-          if (' ' != prompt.back())
-            std::cout << ' ';
-          epee::log_space::reset_console_color();
-          std::cout.flush();
-        }
+        print_prompt();
 
         std::string command;
         bool get_line_ret = m_stdin_reader.get_line(command);
@@ -313,6 +319,7 @@ namespace epee
   private:
     async_stdin_reader m_stdin_reader;
     std::atomic<bool> m_running = {true};
+    std::string m_prompt;
   };
 
 
@@ -446,6 +453,11 @@ namespace epee
     bool run_handling(const std::string& prompt, const std::string& usage_string, std::function<void(void)> exit_handler = NULL)
     {
       return m_console_handler.run(boost::bind(&console_handlers_binder::process_command_str, this, _1), prompt, usage_string, exit_handler);
+    }
+
+    void print_prompt()
+    {
+      m_console_handler.print_prompt();
     }
   };
 

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -77,6 +77,8 @@ namespace cryptonote
 
     bool run_console_handler();
 
+    void wallet_refresh_thread();
+
     bool new_wallet(const std::string &wallet_file, const std::string& password, const crypto::secret_key& recovery_key,
         bool recover, bool two_random, bool testnet, const std::string &old_language);
     bool new_wallet(const std::string &wallet_file, const std::string& password, const cryptonote::account_public_address& address,
@@ -101,6 +103,7 @@ namespace cryptonote
     bool set_always_confirm_transfers(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_store_tx_info(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_default_mixin(const std::vector<std::string> &args = std::vector<std::string>());
+    bool set_auto_refresh(const std::vector<std::string> &args = std::vector<std::string>());
     bool help(const std::vector<std::string> &args = std::vector<std::string>());
     bool start_mining(const std::vector<std::string> &args);
     bool stop_mining(const std::vector<std::string> &args);
@@ -229,5 +232,11 @@ namespace cryptonote
     std::unique_ptr<tools::wallet2> m_wallet;
     epee::net_utils::http::http_simple_client m_http_client;
     refresh_progress_reporter_t m_refresh_progress_reporter;
+
+    std::atomic<bool> m_auto_refresh_run;
+    bool m_auto_refresh_refreshing;
+    std::thread m_auto_refresh_thread;
+    std::mutex m_auto_refresh_mutex;
+    std::condition_variable m_auto_refresh_cond;
   };
 }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -744,6 +744,9 @@ bool wallet2::store_keys(const std::string& keys_file_name, const std::string& p
   value2.SetUint(m_default_mixin);
   json.AddMember("default_mixin", value2, json.GetAllocator());
 
+  value2.SetInt(m_auto_refresh ? 1 :0);
+  json.AddMember("auto_refresh", value2, json.GetAllocator());
+
   // Serialize the JSON object
   rapidjson::StringBuffer buffer;
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
@@ -828,6 +831,7 @@ void wallet2::load_keys(const std::string& keys_file_name, const std::string& pa
     m_store_tx_info = (json.HasMember("store_tx_keys") && (json["store_tx_keys"].GetInt() != 0))
                    || (json.HasMember("store_tx_info") && (json["store_tx_info"].GetInt() != 0));
     m_default_mixin = json.HasMember("default_mixin") ? json["default_mixin"].GetUint() : 0;
+    m_auto_refresh = json.HasMember("auto_refresh") && (json["auto_refresh"].GetInt() != 0);
   }
 
   const cryptonote::account_keys& keys = m_account.get_keys();

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -87,10 +87,10 @@ namespace tools
     };
 
   private:
-    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers (false), m_store_tx_info(true), m_default_mixin(0), m_refresh_type(RefreshOptimizeCoinbase) {}
+    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers (false), m_store_tx_info(true), m_default_mixin(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true) {}
 
   public:
-    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_restricted(restricted), is_old_file_format(false), m_store_tx_info(true), m_default_mixin(0), m_refresh_type(RefreshOptimizeCoinbase) {}
+    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_restricted(restricted), is_old_file_format(false), m_store_tx_info(true), m_default_mixin(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true) {}
     struct transfer_details
     {
       uint64_t m_block_height;
@@ -330,6 +330,8 @@ namespace tools
     void store_tx_info(bool store) { m_store_tx_info = store; }
     uint32_t default_mixin() const { return m_default_mixin; }
     void default_mixin(uint32_t m) { m_default_mixin = m; }
+    bool auto_refresh() const { return m_auto_refresh; }
+    void auto_refresh(bool r) { m_auto_refresh = r; }
 
     bool get_tx_key(const crypto::hash &txid, crypto::secret_key &tx_key) const;
 
@@ -397,6 +399,7 @@ namespace tools
     bool m_store_tx_info; /*!< request txkey to be returned in RPC, and store in the wallet cache file */
     uint32_t m_default_mixin;
     RefreshType m_refresh_type;
+    bool m_auto_refresh;
   };
 }
 BOOST_CLASS_VERSION(tools::wallet2, 10)


### PR DESCRIPTION
The daemon will be polled every 90 seconds for new blocks.
It is enabled by default, and can be turned on/off with
set auto-refresh 1 and set auto-refresh 0 in the wallet.