### PR TITLE
wallet: cancellable refresh

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -48,7 +48,7 @@ using namespace epee;
 
 namespace tools
 {
-  std::function<void(void)> signal_handler::m_handler; 
+  std::function<void(int)> signal_handler::m_handler;
 
 #ifdef WIN32
   std::string get_windows_version_display_string()

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -130,7 +130,7 @@ namespace tools
     {
       if (CTRL_C_EVENT == type || CTRL_BREAK_EVENT == type)
       {
-        handle_signal();
+        handle_signal(type);
       }
       else
       {
@@ -141,21 +141,21 @@ namespace tools
     }
 #else
     /*! \brief handler for NIX */
-    static void posix_handler(int /*type*/)
+    static void posix_handler(int type)
     {
-      handle_signal();
+      handle_signal(type);
     }
 #endif
 
     /*! \brief calles m_handler */
-    static void handle_signal()
+    static void handle_signal(int type)
     {
       static std::mutex m_mutex;
       std::unique_lock<std::mutex> lock(m_mutex);
-      m_handler();
+      m_handler(type);
     }
 
     /*! \brief where the installed handler is stored */
-    static std::function<void(void)> m_handler;
+    static std::function<void(int)> m_handler;
   };
 }

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -68,6 +68,7 @@ namespace cryptonote
     bool deinit();
     bool run();
     void stop();
+    void interrupt();
 
     //wallet *create_wallet();
     bool process_command(const std::vector<std::string> &args);
@@ -134,6 +135,7 @@ namespace cryptonote
     uint64_t get_daemon_blockchain_height(std::string& err);
     bool try_connect_to_daemon();
     bool ask_wallet_create_if_needed();
+
     /*!
      * \brief Prints the seed with a nice message
      * \param seed seed to print
@@ -238,5 +240,6 @@ namespace cryptonote
     std::thread m_auto_refresh_thread;
     std::mutex m_auto_refresh_mutex;
     std::condition_variable m_auto_refresh_cond;
+    std::atomic<bool> m_in_manual_refresh;
   };
 }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -680,6 +680,7 @@ void wallet2::refresh(uint64_t start_height, uint64_t & blocks_fetched, bool& re
   get_short_chain_history(short_chain_history);
   pull_blocks(start_height, blocks_start_height, short_chain_history, blocks);
 
+  m_run.store(true, std::memory_order_relaxed);
   while(m_run.load(std::memory_order_relaxed))
   {
     try


### PR DESCRIPTION
^C while in manual refresh will cancel the refresh, since that's
often an annoying thing to have to wait for. Also, a manual refresh
command will interrupt any running background refresh and take
over, rather than wait for the background refresh to be done, and
look to be hanging.