### PR TITLE
db_bdb: move log_set_config call before open

### DIFF
--- a/src/blockchain_db/berkeleydb/db_bdb.cpp
+++ b/src/blockchain_db/berkeleydb/db_bdb.cpp
@@ -780,12 +780,12 @@ void BlockchainBDB::open(const std::string& filename, const int db_flags)
         m_env->set_lk_max_lockers(DB_MAX_LOCKS);
         m_env->set_lk_max_objects(DB_MAX_LOCKS);
         
+        if(m_auto_remove_logs)
+          m_env->log_set_config(DB_LOG_AUTO_REMOVE, 1);
+
         // last parameter left 0, files will be created with default rw access
         m_env->open(filename.c_str(), db_env_open_flags, 0);
         m_env->set_flags(db_flags, 1);
-
-        if(m_auto_remove_logs)
-        	m_env->log_set_config(DB_LOG_AUTO_REMOVE, 1);
 
         // begin transaction to init dbs
         bdb_txn_safe txn;


### PR DESCRIPTION
This is a precaution for older Berkeley DB versions.

- smooth reports an issue running with 4.7:
  DB_ENV->log_set_config: DB_LOG_IN_MEMORY: method not permitted
  after handle's open method
- this works just fine with 5.3
- we do not use DB_LOG_IN_MEMORY, but we use DB_LOG_AUTO_REMOVE
- libdb docs say some flags must be set before open, and some
  may be set at any time, but never say some must be set after
  open
- moving the call to log_set_config before open works with 5.3

Therefore, it seems best to move the call before open.