### PR TITLE
Register daemon command line arguments to core if they're used in core

### DIFF
--- a/src/common/command_line.cpp
+++ b/src/common/command_line.cpp
@@ -51,4 +51,44 @@ namespace command_line
   const arg_descriptor<bool>		arg_test_drop_download  		= {"test-drop-download", "For net tests: in download, discard ALL blocks instead checking/saving them (very fast)"};
   const arg_descriptor<uint64_t>	arg_test_drop_download_height  	= {"test-drop-download-height", "Like test-drop-download but disards only after around certain height", 0};
   const arg_descriptor<int> 		arg_test_dbg_lock_sleep = {"test-dbg-lock-sleep", "Sleep time in ms, defaults to 0 (off), used to debug before/after locking mutex. Values 100 to 1000 are good for tests."};
+  const arg_descriptor<bool, false> arg_testnet_on  = {
+    "testnet"
+  , "Run on testnet. The wallet must be launched with --testnet flag."
+  , false
+  };
+  const arg_descriptor<bool> arg_dns_checkpoints  = {
+    "enforce-dns-checkpointing"
+  , "checkpoints from DNS server will be enforced"
+  , false
+  };
+  const command_line::arg_descriptor<std::string> arg_db_type = {
+    "db-type"
+  , "Specify database type"
+  , DEFAULT_DB_TYPE
+  };
+  const command_line::arg_descriptor<std::string> arg_db_sync_mode = {
+    "db-sync-mode"
+  , "Specify sync option, using format [safe|fast|fastest]:[sync|async]:[nblocks_per_sync]." 
+  , "fastest:async:1000"
+  };
+  const command_line::arg_descriptor<uint64_t> arg_fast_block_sync = {
+    "fast-block-sync"
+  , "Sync up most of the way by using embedded, known block hashes."
+  , 1
+  };
+  const command_line::arg_descriptor<uint64_t> arg_prep_blocks_threads = {
+    "prep-blocks-threads"
+  , "Max number of threads to use when preparing block hashes in groups."
+  , 4
+  };
+  const command_line::arg_descriptor<uint64_t> arg_db_auto_remove_logs  = {
+    "db-auto-remove-logs"
+  , "For BerkeleyDB only. Remove transactions logs automatically."
+  , 1
+  };
+  const command_line::arg_descriptor<uint64_t> arg_show_time_stats  = {
+    "show-time-stats"
+  , "Show time-stats when processing blocks/txs and disk synchronization."
+  , 0
+  };
 }

--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -207,4 +207,12 @@ namespace command_line
   extern const arg_descriptor<bool>		arg_test_drop_download;
   extern const arg_descriptor<uint64_t>	arg_test_drop_download_height;
   extern const arg_descriptor<int> 		arg_test_dbg_lock_sleep;
+  extern const arg_descriptor<bool, false> arg_testnet_on;
+  extern const arg_descriptor<bool> arg_dns_checkpoints;
+  extern const arg_descriptor<std::string> arg_db_type;
+  extern const arg_descriptor<std::string> arg_db_sync_mode;
+  extern const arg_descriptor<uint64_t> arg_fast_block_sync;
+  extern const arg_descriptor<uint64_t> arg_prep_blocks_threads;
+  extern const arg_descriptor<uint64_t> arg_db_auto_remove_logs;
+  extern const arg_descriptor<uint64_t> arg_show_time_stats;
 }

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -42,7 +42,6 @@ using namespace epee;
 #include "cryptonote_format_utils.h"
 #include "misc_language.h"
 #include <csignal>
-#include "daemon/command_line_args.h"
 #include "cryptonote_core/checkpoints_create.h"
 #include "blockchain_db/blockchain_db.h"
 #include "blockchain_db/lmdb/db_lmdb.h"
@@ -130,13 +129,27 @@ namespace cryptonote
     graceful_exit();
   }
   //-----------------------------------------------------------------------------------
-  void core::init_options(boost::program_options::options_description& /*desc*/)
+  void core::init_options(boost::program_options::options_description& desc)
   {
+    command_line::add_arg(desc, command_line::arg_data_dir, tools::get_default_data_dir());
+    command_line::add_arg(desc, command_line::arg_testnet_data_dir, (boost::filesystem::path(tools::get_default_data_dir()) / "testnet").string());
+
+    command_line::add_arg(desc, command_line::arg_test_drop_download);
+    command_line::add_arg(desc, command_line::arg_test_drop_download_height);
+
+    command_line::add_arg(desc, command_line::arg_testnet_on);
+    command_line::add_arg(desc, command_line::arg_dns_checkpoints);
+    command_line::add_arg(desc, command_line::arg_db_type);
+    command_line::add_arg(desc, command_line::arg_prep_blocks_threads);
+    command_line::add_arg(desc, command_line::arg_fast_block_sync);
+    command_line::add_arg(desc, command_line::arg_db_sync_mode);
+    command_line::add_arg(desc, command_line::arg_show_time_stats);
+    command_line::add_arg(desc, command_line::arg_db_auto_remove_logs);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::handle_command_line(const boost::program_options::variables_map& vm)
   {
-    m_testnet = command_line::get_arg(vm, daemon_args::arg_testnet_on);
+    m_testnet = command_line::get_arg(vm, command_line::arg_testnet_on);
 
     auto data_dir_arg = m_testnet ? command_line::arg_testnet_data_dir : command_line::arg_data_dir;
     m_config_folder = command_line::get_arg(vm, data_dir_arg);
@@ -159,7 +172,7 @@ namespace cryptonote
     }
 
 
-    set_enforce_dns_checkpoints(command_line::get_arg(vm, daemon_args::arg_dns_checkpoints));
+    set_enforce_dns_checkpoints(command_line::get_arg(vm, command_line::arg_dns_checkpoints));
     test_drop_download_height(command_line::get_arg(vm, command_line::arg_test_drop_download_height));
     
     if (command_line::get_arg(vm, command_line::arg_test_drop_download) == true)
@@ -211,10 +224,10 @@ namespace cryptonote
     CHECK_AND_ASSERT_MES(r, false, "Failed to initialize memory pool");
 
 #if BLOCKCHAIN_DB == DB_LMDB
-    std::string db_type = command_line::get_arg(vm, daemon_args::arg_db_type);
-    std::string db_sync_mode = command_line::get_arg(vm, daemon_args::arg_db_sync_mode);
-    bool fast_sync = command_line::get_arg(vm, daemon_args::arg_fast_block_sync) != 0;
-    uint64_t blocks_threads = command_line::get_arg(vm, daemon_args::arg_prep_blocks_threads);
+    std::string db_type = command_line::get_arg(vm, command_line::arg_db_type);
+    std::string db_sync_mode = command_line::get_arg(vm, command_line::arg_db_sync_mode);
+    bool fast_sync = command_line::get_arg(vm, command_line::arg_fast_block_sync) != 0;
+    uint64_t blocks_threads = command_line::get_arg(vm, command_line::arg_prep_blocks_threads);
 
     BlockchainDB* db = nullptr;
     uint64_t BDB_FAST_MODE = 0;
@@ -309,7 +322,7 @@ namespace cryptonote
           blocks_per_sync = 1;
       }
 
-      bool auto_remove_logs = command_line::get_arg(vm, daemon_args::arg_db_auto_remove_logs) != 0;
+      bool auto_remove_logs = command_line::get_arg(vm, command_line::arg_db_auto_remove_logs) != 0;
       db->set_auto_remove_logs(auto_remove_logs);
       db->open(filename, db_flags);
       if(!db->m_open)
@@ -326,7 +339,7 @@ namespace cryptonote
 
     r = m_blockchain_storage.init(db, m_testnet);
 
-    bool show_time_stats = command_line::get_arg(vm, daemon_args::arg_show_time_stats) != 0;
+    bool show_time_stats = command_line::get_arg(vm, command_line::arg_show_time_stats) != 0;
     m_blockchain_storage.set_show_time_stats(show_time_stats);
 #else
     r = m_blockchain_storage.init(m_config_folder, m_testnet);

--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -60,47 +60,6 @@ namespace daemon_args
     "os-version"
   , "OS for which this executable was compiled"
   };
-  const command_line::arg_descriptor<bool> arg_testnet_on  = {
-    "testnet"
-  , "Run on testnet. The wallet must be launched with --testnet flag."
-  , false
-  };
-  const command_line::arg_descriptor<bool> arg_dns_checkpoints  = {
-    "enforce-dns-checkpointing"
-  , "checkpoints from DNS server will be enforced"
-  , false
-  };
-  const command_line::arg_descriptor<std::string> arg_db_type = {
-    "db-type"
-  , "Specify database type"
-  , DEFAULT_DB_TYPE
-  };
-  const command_line::arg_descriptor<uint64_t> arg_prep_blocks_threads = {
-    "prep-blocks-threads"
-  , "Max number of threads to use when preparing block hashes in groups."
-  , 4
-  };
-  const command_line::arg_descriptor<uint64_t> arg_fast_block_sync = {
-    "fast-block-sync"
-  , "Sync up most of the way by using embedded, known block hashes."
-  , 1
-  };
-  const command_line::arg_descriptor<uint64_t> arg_show_time_stats  = {
-    "show-time-stats"
-  , "Show time-stats when processing blocks/txs and disk synchronization."
-  , 0
-  };
-  const command_line::arg_descriptor<uint64_t> arg_db_auto_remove_logs  = {
-    "db-auto-remove-logs"
-  , "For BerkeleyDB only. Remove transactions logs automatically."
-  , 1
-  };
-  const command_line::arg_descriptor<std::string> arg_db_sync_mode = {
-    "db-sync-mode"
-  , "Specify sync option, using format [safe|fast|fastest]:[sync|async]:[nblocks_per_sync]." 
-  , "fastest:async:1000"
-  };
-;
 }  // namespace daemon_args
 
 #endif // DAEMON_COMMAND_LINE_ARGS_H

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -73,26 +73,15 @@ int main(int argc, char const * argv[])
       command_line::add_arg(visible_options, command_line::arg_help);
       command_line::add_arg(visible_options, command_line::arg_version);
       command_line::add_arg(visible_options, daemon_args::arg_os_version);
-      command_line::add_arg(visible_options, command_line::arg_data_dir, default_data_dir.string());
-      command_line::add_arg(visible_options, command_line::arg_testnet_data_dir, default_testnet_data_dir.string());
       bf::path default_conf = default_data_dir / std::string(CRYPTONOTE_NAME ".conf");
       command_line::add_arg(visible_options, daemon_args::arg_config_file, default_conf.string());
-      command_line::add_arg(visible_options, command_line::arg_test_drop_download);
       command_line::add_arg(visible_options, command_line::arg_test_dbg_lock_sleep);
-      command_line::add_arg(visible_options, command_line::arg_test_drop_download_height);
+      cryptonote::core::init_options(core_settings);
     
       // Settings
       bf::path default_log = default_data_dir / std::string(CRYPTONOTE_NAME ".log");
       command_line::add_arg(core_settings, daemon_args::arg_log_file, default_log.string());
       command_line::add_arg(core_settings, daemon_args::arg_log_level);
-      command_line::add_arg(core_settings, daemon_args::arg_testnet_on);
-      command_line::add_arg(core_settings, daemon_args::arg_dns_checkpoints);
-      command_line::add_arg(core_settings, daemon_args::arg_db_type);
-      command_line::add_arg(core_settings, daemon_args::arg_prep_blocks_threads);
-      command_line::add_arg(core_settings, daemon_args::arg_fast_block_sync);
-      command_line::add_arg(core_settings, daemon_args::arg_db_sync_mode);
-      command_line::add_arg(core_settings, daemon_args::arg_show_time_stats);
-      command_line::add_arg(core_settings, daemon_args::arg_db_auto_remove_logs);
 
       daemonizer::init_options(hidden_options, visible_options);
       daemonize::t_executor::init_options(core_settings);
@@ -146,7 +135,7 @@ int main(int argc, char const * argv[])
     
     epee::g_test_dbg_lock_sleep = command_line::get_arg(vm, command_line::arg_test_dbg_lock_sleep);
 
-    std::string db_type = command_line::get_arg(vm, daemon_args::arg_db_type);
+    std::string db_type = command_line::get_arg(vm, command_line::arg_db_type);
 
     // verify that blockchaindb type is valid
     if(cryptonote::blockchain_db_types.count(db_type) == 0)
@@ -159,7 +148,7 @@ int main(int argc, char const * argv[])
       return 0;
     }
 
-    bool testnet_mode = command_line::get_arg(vm, daemon_args::arg_testnet_on);
+    bool testnet_mode = command_line::get_arg(vm, command_line::arg_testnet_on);
 
     auto data_dir_arg = testnet_mode ? command_line::arg_testnet_data_dir : command_line::arg_data_dir;
 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -49,7 +49,6 @@
 #include "crypto/crypto.h"
 #include "storages/levin_abstract_invoke2.h"
 #include "data_logger.hpp"
-#include "daemon/command_line_args.h"
 
 // We have to look for miniupnpc headers in different places, dependent on if its compiled or external
 #ifdef UPNP_STATIC
@@ -342,7 +341,7 @@ namespace nodetool
   bool node_server<t_payload_net_handler>::init(const boost::program_options::variables_map& vm)
   {
     std::set<std::string> full_addrs;
-    bool testnet = command_line::get_arg(vm, daemon_args::arg_testnet_on);
+    bool testnet = command_line::get_arg(vm, command_line::arg_testnet_on);
 
     if (testnet)
     {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -40,7 +40,6 @@ using namespace epee;
 #include "misc_language.h"
 #include "crypto/hash.h"
 #include "core_rpc_server_error_codes.h"
-#include "daemon/command_line_args.h"
 
 namespace cryptonote
 {
@@ -78,7 +77,7 @@ namespace cryptonote
       const boost::program_options::variables_map& vm
     )
   {
-    m_testnet = command_line::get_arg(vm, daemon_args::arg_testnet_on);
+    m_testnet = command_line::get_arg(vm, command_line::arg_testnet_on);
 
     m_net_server.set_threads_prefix("RPC");
     bool r = handle_command_line(vm);


### PR DESCRIPTION
This fixes coretests, which does not register daemon specific arguments,
but uses core, which uses those arguments. Also gets rid of an unwanted
dependency on daemon code from core.