### PR TITLE
Bugus on fork processing

### DIFF
--- a/src/daemonizer/posix_fork.cpp
+++ b/src/daemonizer/posix_fork.cpp
@@ -26,6 +26,39 @@ namespace {
 
 void fork()
 {
+
+  // Close the standard streams. This decouples the daemon from the terminal
+  // that started it.
+
+
+  close(0);
+  close(1);
+  close(2);
+
+  // We don't want the daemon to have any standard input.
+  if (open("/dev/null", O_RDONLY) < 0)
+  {
+    quit("Unable to open /dev/null");
+  }
+
+  // A process inherits its working directory from its parent. This could be
+  // on a mounted filesystem, which means that the running daemon would
+  // prevent this filesystem from being unmounted. Changing to the root
+  // directory avoids this problem.
+  if (chdir("/") < 0)
+  {
+    quit("Unable to change working directory to root");
+  }
+
+
+
+  // The file mode creation mask is also inherited from the parent process.
+  // We don't want to restrict the permissions on files created by the
+  // daemon, so the mask is cleared.
+  umask(0);
+
+
+
   // Fork the process and have the parent exit. If the process was started
   // from a shell, this returns control to the user. Forking a new process is
   // also a prerequisite for the subsequent call to setsid().
@@ -50,46 +83,7 @@ void fork()
   // terminal.
   setsid();
 
-  // A process inherits its working directory from its parent. This could be
-  // on a mounted filesystem, which means that the running daemon would
-  // prevent this filesystem from being unmounted. Changing to the root
-  // directory avoids this problem.
-  if (chdir("/") < 0)
-  {
-    quit("Unable to change working directory to root");
-  }
-
-  // The file mode creation mask is also inherited from the parent process.
-  // We don't want to restrict the permissions on files created by the
-  // daemon, so the mask is cleared.
-  umask(0);
-
-  // A second fork ensures the process cannot acquire a controlling terminal.
-  if (pid_t pid = ::fork())
-  {
-    if (pid > 0)
-    {
-      exit(0);
-    }
-    else
-    {
-      quit("Second fork failed");
-    }
-  }
-
-  // Close the standard streams. This decouples the daemon from the terminal
-  // that started it.
-  close(0);
-  close(1);
-  close(2);
-
-  // We don't want the daemon to have any standard input.
-  if (open("/dev/null", O_RDONLY) < 0)
-  {
-    quit("Unable to open /dev/null");
-  }
-
-  // Send standard output to a log file.
+ // Send standard output to a log file.
   const char* output = "/tmp/bitmonero.daemon.stdout.stderr";
   const int flags = O_WRONLY | O_CREAT | O_APPEND;
   const mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;


### PR DESCRIPTION
Main process is 25401
```
strace -f bitmonerod --detach 2>&1 | grep 'exit_group'
[pid 25401] exit_group(0)               = ?
```

25409 First fork is not quit :(
```
ps -axo ppid,pid,tty,args  | grep bitmonerod
         1 25409 ?        bitmonerod --detach
 25409 25410 ?        bitmonerod --detach
```




http://linux.die.net/man/1/daemonize

Need only 1 fork

Close all standard descriptor in main process  
Change directory on main process
Reset umask  on main process

Fork 
exit main process
detach and attache init