### PR TITLE
posix_daemonizer: only create the main daemon object in the last child

### DIFF
--- a/src/daemonizer/posix_daemonizer.inl
+++ b/src/daemonizer/posix_daemonizer.inl
@@ -74,9 +74,9 @@ namespace daemonizer
   {
     if (command_line::has_arg(vm, arg_detach))
     {
-      auto daemon = executor.create_daemon(vm);
       tools::success_msg_writer() << "Forking to background...";
       posix::fork();
+      auto daemon = executor.create_daemon(vm);
       return daemon.run();
     }
     else


### PR DESCRIPTION
This prevents the intermediate thread from exiting properly, as
fork creates a child process with only one thread, so any existing
data_logger thread will not be in the child. Since this thread
sets a flag the data_logger dtor blocks on, all children threads
will hang on exit.