### PR TITLE
daemon: fix crash exiting with ^C

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -114,7 +114,7 @@ bool t_daemon::run(bool interactive)
   {
     throw std::runtime_error{"Can't run stopped daemon"};
   }
-  tools::signal_handler::install(std::bind(&daemonize::t_daemon::stop, this));
+  tools::signal_handler::install(std::bind(&daemonize::t_daemon::stop_p2p, this));
 
   try
   {


### PR DESCRIPTION
We need to stop the p2p layer, which causes the rest to shutdown
gracefully. Hitting ^C was still going through another path.