### PR TITLE
Strip redundant includes

### DIFF
--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -31,7 +31,6 @@
 
 #include "common/command_line.h"
 #include "cryptonote_config.h"
-#include <boost/program_options.hpp>
 
 namespace daemon_args
 {

--- a/src/daemon/core.h
+++ b/src/daemon/core.h
@@ -32,8 +32,6 @@
 #include "cryptonote_core/cryptonote_core.h"
 #include "cryptonote_protocol/cryptonote_protocol_handler.h"
 #include "misc_log_ex.h"
-#include <stdexcept>
-#include <boost/program_options.hpp>
 #include "daemon/command_line_args.h"
 
 namespace daemonize

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -28,6 +28,9 @@
 //
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
+#include <memory>
+#include <stdexcept>
+#include "misc_log_ex.h"
 #include "daemon/daemon.h"
 
 #include "common/util.h"
@@ -36,15 +39,12 @@
 #include "daemon/protocol.h"
 #include "daemon/rpc.h"
 #include "daemon/command_server.h"
-#include "misc_log_ex.h"
 #include "version.h"
 #include "../../contrib/epee/include/syncobj.h"
 
 using namespace epee;
 
-#include <boost/program_options.hpp>
 #include <functional>
-#include <memory>
 
 unsigned int epee::g_test_dbg_lock_sleep = 0;
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -27,8 +27,6 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
-
-#include <memory>
 #include <boost/program_options.hpp>
 
 namespace daemonize {

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -40,7 +40,6 @@
 #include "misc_log_ex.h"
 #include "p2p/net_node.h"
 #include "rpc/core_rpc_server.h"
-#include <boost/program_options.hpp>
 #include "daemon/command_line_args.h"
 #include "blockchain_db/db_types.h"
 

--- a/src/daemon/p2p.h
+++ b/src/daemon/p2p.h
@@ -31,11 +31,8 @@
 #pragma once
 
 #include "cryptonote_protocol/cryptonote_protocol_handler.h"
-#include "daemon/protocol.h"
-#include "misc_log_ex.h"
 #include "p2p/net_node.h"
-#include <stdexcept>
-#include <boost/program_options.hpp>
+#include "daemon/protocol.h"
 
 namespace daemonize
 {

--- a/src/daemon/protocol.h
+++ b/src/daemon/protocol.h
@@ -30,12 +30,6 @@
 
 #pragma once
 
-#include "cryptonote_protocol/cryptonote_protocol_handler.h"
-#include "misc_log_ex.h"
-#include "p2p/net_node.h"
-#include <stdexcept>
-#include <boost/program_options.hpp>
-
 namespace daemonize
 {
 

--- a/src/daemon/rpc.h
+++ b/src/daemon/rpc.h
@@ -30,12 +30,7 @@
 
 #pragma once
 
-#include "daemon/core.h"
-#include "daemon/p2p.h"
-#include "misc_log_ex.h"
 #include "rpc/core_rpc_server.h"
-#include <boost/program_options.hpp>
-#include <stdexcept>
 
 namespace daemonize
 {


### PR DESCRIPTION
In particular, <boost/program_options.hpp> blows up daemon.cpp.obj,
making it too big to compile in debug mode on Win32. Even on a
release build it drops daemon.cpp.o on Linux from 31MB to 20MB.
This has no effect on the final linked binary size.