### PR TITLE
BlockchainDB: Remove txs in reverse order

### DIFF
--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -26,6 +26,8 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <boost/range/adaptor/reversed.hpp>
+
 #include "blockchain_db.h"
 #include "cryptonote_core/cryptonote_format_utils.h"
 #include "profile_tools.h"
@@ -133,13 +135,13 @@ void BlockchainDB::pop_block(block& blk, std::vector<transaction>& txs)
   blk = get_top_block();
 
   remove_block();
-  
-  remove_transaction(get_transaction_hash(blk.miner_tx));
-  for (const auto& h : blk.tx_hashes)
+
+  for (const auto& h : boost::adaptors::reverse(blk.tx_hashes))
   {
     txs.push_back(get_tx(h));
     remove_transaction(h);
   }
+  remove_transaction(get_transaction_hash(blk.miner_tx));
 }
 
 bool BlockchainDB::is_open() const

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -722,15 +722,15 @@ void BlockchainLMDB::remove_tx_outputs(const crypto::hash& tx_hash, const transa
     size_t num_elems = 0;
     mdb_cursor_count(cur, &num_elems);
 
-    mdb_cursor_get(cur, &k, &v, MDB_FIRST_DUP);
+    mdb_cursor_get(cur, &k, &v, MDB_LAST_DUP);
 
-    for (uint64_t i = 0; i < num_elems; ++i)
+    for (uint64_t i = num_elems; i > 0; --i)
     {
-      const tx_out tx_output = tx.vout[i];
+      const tx_out tx_output = tx.vout[i-1];
       remove_output(*(const uint64_t*)v.mv_data, tx_output.amount);
-      if (i < num_elems - 1)
+      if (i > 1)
       {
-        mdb_cursor_get(cur, &k, &v, MDB_NEXT_DUP);
+        mdb_cursor_get(cur, &k, &v, MDB_PREV_DUP);
       }
     }
   }

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -806,22 +806,23 @@ void BlockchainLMDB::remove_amount_output_index(const uint64_t amount, const uin
   size_t num_elems = 0;
   mdb_cursor_count(cur, &num_elems);
 
-  mdb_cursor_get(cur, &k, &v, MDB_FIRST_DUP);
+  mdb_cursor_get(cur, &k, &v, MDB_LAST_DUP);
 
   uint64_t amount_output_index = 0;
   uint64_t goi = 0;
   bool found_index = false;
-  for (uint64_t i = 0; i < num_elems; ++i)
+  for (uint64_t i = num_elems; i > 0; --i)
   {
     mdb_cursor_get(cur, &k, &v, MDB_GET_CURRENT);
     goi = *(const uint64_t *)v.mv_data;
     if (goi == global_output_index)
     {
-      amount_output_index = i;
+      amount_output_index = i-1;
       found_index = true;
       break;
     }
-    mdb_cursor_get(cur, &k, &v, MDB_NEXT_DUP);
+    if (i > 1)
+      mdb_cursor_get(cur, &k, &v, MDB_PREV_DUP);
   }
   if (found_index)
   {


### PR DESCRIPTION
Data should be removed in the reverse order it was added. Not doing so breaks assumptions and can cause problems in other DB implementations.

This matches the order of tx removal in `blockchain_storage::purge_block_data_from_blockchain`.