### PR TITLE
BlockchainDB: skip fixup check if read-only database

### DIFF
--- a/src/blockchain_db/berkeleydb/db_bdb.cpp
+++ b/src/blockchain_db/berkeleydb/db_bdb.cpp
@@ -2200,8 +2200,14 @@ void BlockchainBDB::checkpoint_worker() const
     LOG_PRINT_L0("Leaving BDB checkpoint thread.");
 }
 
+bool BlockchainBDB::is_read_only() const
+{
+  return false;
+}
+
 void BlockchainBDB::fixup()
 {
+  LOG_PRINT_L3("BlockchainBDB::" << __func__);
   // Always call parent as well
   BlockchainDB::fixup();
 }

--- a/src/blockchain_db/berkeleydb/db_bdb.h
+++ b/src/blockchain_db/berkeleydb/db_bdb.h
@@ -405,6 +405,9 @@ private:
   uint64_t get_output_global_index(const uint64_t& amount, const uint64_t& index);
   void checkpoint_worker() const;
   void check_open() const;
+
+  virtual bool is_read_only() const;
+
   //
   // fix up anything that may be wrong due to past bugs
   virtual void fixup();

--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -199,6 +199,11 @@ void BlockchainDB::show_stats()
 
 void BlockchainDB::fixup()
 {
+  if (is_read_only()) {
+    LOG_PRINT_L1("Database is opened read only - skipping fixup check");
+    return;
+  }
+
   // There was a bug that would cause key images for transactions without
   // any outputs to not be added to the spent key image set. There are two
   // instances of such transactions, in blocks 202612 and 685498.

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -503,6 +503,8 @@ public:
   virtual void set_hard_fork_version(uint64_t height, uint8_t version) = 0;
   virtual uint8_t get_hard_fork_version(uint64_t height) const = 0;
 
+  virtual bool is_read_only() const = 0;
+
   // fix up anything that may be wrong due to past bugs
   virtual void fixup();
 

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -2496,8 +2496,22 @@ uint8_t BlockchainLMDB::get_hard_fork_version(uint64_t height) const
   return ret;
 }
 
+bool BlockchainLMDB::is_read_only() const
+{
+  unsigned int flags;
+  auto result = mdb_env_get_flags(m_env, &flags);
+  if (result)
+    throw0(DB_ERROR(std::string("Error getting database environment info: ").append(mdb_strerror(result)).c_str()));
+
+  if (flags & MDB_RDONLY)
+    return true;
+
+  return false;
+}
+
 void BlockchainLMDB::fixup()
 {
+  LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   // Always call parent as well
   BlockchainDB::fixup();
 }

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -266,6 +266,8 @@ private:
 
   void check_open() const;
 
+  virtual bool is_read_only() const;
+
   // fix up anything that may be wrong due to past bugs
   virtual void fixup();
 


### PR DESCRIPTION
This is needed for utilities like blockchain_export, which don't need to make any DB writes.