### PR TITLE
wallet: don't forget to close the file after storing cache

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1288,9 +1288,11 @@ void wallet2::store()
   const std::string old_file = m_wallet_file + ".old";
 
   // save to new file
-  std::ofstream ostr(new_file);
+  std::ofstream ostr;
+  ostr.open(new_file, std::ios_base::binary | std::ios_base::out | std::ios_base::trunc);
   binary_archive<true> oar(ostr);
   bool success = ::serialization::serialize(oar, cache_file_data);
+  ostr.close();
   THROW_WALLET_EXCEPTION_IF(!success || !ostr.good(), error::file_save_error, new_file);
 
   // rename


### PR DESCRIPTION
Also add some flags to open, as epee's save_string_to_file does,
to truncate file, etc.