### PR TITLE
core: do not use the persistent pool state for tests

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -222,7 +222,7 @@ namespace cryptonote
   {
     bool r = handle_command_line(vm);
 
-    r = m_mempool.init(m_config_folder);
+    r = m_mempool.init(m_fakechain ? std::string() : m_config_folder);
     CHECK_AND_ASSERT_MES(r, false, "Failed to initialize memory pool");
 
 #if BLOCKCHAIN_DB == DB_LMDB

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -612,6 +612,9 @@ namespace cryptonote
     CRITICAL_REGION_LOCAL(m_transactions_lock);
 
     m_config_folder = config_folder;
+    if (m_config_folder.empty())
+      return true;
+
     std::string state_file_path = config_folder + "/" + CRYPTONOTE_POOLDATA_FILENAME;
     boost::system::error_code ec;
     if(!boost::filesystem::exists(state_file_path, ec))
@@ -648,6 +651,9 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::deinit()
   {
+    if (m_config_folder.empty())
+      return true;
+
     if (!tools::create_directories_if_necessary(m_config_folder))
     {
       LOG_PRINT_L1("Failed to create data directory: " << m_config_folder);


### PR DESCRIPTION
Fixes intermittent test failures when the pool contains
unexpected transactions that were brought in from the
live pool.