### PR TITLE
IP_TOS not supported before Windows7

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -160,13 +160,16 @@ PRAGMA_WARNING_DISABLE_VS(4355)
         boost::bind(&connection<t_protocol_handler>::handle_read, self,
           boost::asio::placeholders::error,
           boost::asio::placeholders::bytes_transferred)));
-          
+#if !defined(_WIN32) || !defined(__i686)
+	// not supported before Windows7, too lazy for runtime check
+	// Just exclude for 32bit windows builds
 	//set ToS flag
 	int tos = get_tos_flag();
 	boost::asio::detail::socket_option::integer< IPPROTO_IP, IP_TOS >
 	optionTos( tos );
     socket_.set_option( optionTos );
 	//_dbg1("Set ToS flag to " << tos);
+#endif
 	
 	boost::asio::ip::tcp::no_delay noDelayOption(false);
 	socket_.set_option(noDelayOption);


### PR DESCRIPTION
On Win32 the daemon gets an exception when trying to start a connection. It's caused by trying to set the type of service on the socket. According to MSDN this is not supported before WS2012. Oddly enough the code doesn't crash on Win7 (even tho MSDN would imply that's at least non-working there.)

https://msdn.microsoft.com/en-us/library/windows/desktop/ms738586%28v=vs.85%29.aspx

Going to assume for the moment that any 64-bit Windows is fine, and just exclude this for 32-bit. The Win32 daemon works fine on Windows XPSP3 after patching this out.