### PR TITLE
unit_tests: initialize db object in ctor, not open

### DIFF
--- a/tests/unit_tests/hardfork.cpp
+++ b/tests/unit_tests/hardfork.cpp
@@ -42,10 +42,11 @@ using namespace cryptonote;
 
 class TestDB: public BlockchainDB {
 public:
-  virtual void open(const std::string& filename, const int db_flags = 0) {
+  TestDB() {
     for (size_t n = 0; n < 256; ++n)
       starting_height[n] = std::numeric_limits<uint64_t>::max();
   }
+  virtual void open(const std::string& filename, const int db_flags = 0) { }
   virtual void close() {}
   virtual void sync() {}
   virtual void reset() {}


### PR DESCRIPTION
open isn't actually called in those tests