### PR TITLE
Cleanup symbol clashes, stdlib header

### DIFF
--- a/external/unbound/CMakeLists.txt
+++ b/external/unbound/CMakeLists.txt
@@ -141,7 +141,7 @@ set(common_src
 
 set(compat_src)
 
-foreach (symbol IN ITEMS ctime_r gmtime_r inet_aton inet_ntop inet_pton isblank malloc memcmp memmove snprintf strlcat strlcpy strptime explicit_bzero arc4random arc4random_uniform sha512 reallocarray)
+foreach (symbol IN ITEMS ctime_r gmtime_r inet_aton inet_ntop inet_pton isblank malloc memmove snprintf strlcat strlcpy strptime explicit_bzero arc4random arc4random_uniform reallocarray)
   string(TOUPPER "${symbol}" upper_sym)
   if (NOT HAVE_${upper_sym})
     list(APPEND compat_src

--- a/external/unbound/config.h.cmake.in
+++ b/external/unbound/config.h.cmake.in
@@ -781,8 +781,11 @@
 #endif
 #include <assert.h>
 
-#if STDC_HEADERS
+#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
+#endif
+
+#if STDC_HEADERS
 #include <stddef.h>
 #endif
 


### PR DESCRIPTION
memcmp lacks an appropriate test, the local version is getting used unconditionally.
sha512 lacks a test, the local version is getting used unconditionally and clashes with OpenSSL's.