### PR TITLE
More verbose on successful update of out_peers, slight rewording of command description

### DIFF
--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -177,7 +177,7 @@ t_command_server::t_command_server(
     m_command_lookup.set_handler(
       "out_peers"
     , std::bind(&t_command_parser_executor::out_peers, &m_parser, p::_1)
-    , "Set max limit of out peers"
+    , "Set max number of out peers"
     );
     m_command_lookup.set_handler(
       "start_save_graph"

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -964,7 +964,7 @@ bool t_rpc_command_executor::out_peers(uint64_t limit)
 		}
 	}
 
-	std::cout << "Max limit of out peers set to " << limit << std::endl;
+	std::cout << "Max number of out peers set to " << limit << std::endl;
 
 	return true;
 }

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -964,6 +964,8 @@ bool t_rpc_command_executor::out_peers(uint64_t limit)
 		}
 	}
 
+	std::cout << "Max limit of out peers set to " << limit << std::endl;
+
 	return true;
 }
 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -92,7 +92,7 @@ namespace nodetool
 
     const command_line::arg_descriptor<bool>        arg_no_igd  = {"no-igd", "Disable UPnP port mapping"};
     const command_line::arg_descriptor<bool>        arg_offline = {"offline", "Do not listen for peers, nor connect to any"};
-    const command_line::arg_descriptor<int64_t>     arg_out_peers = {"out-peers", "set max limit of out peers", -1};
+    const command_line::arg_descriptor<int64_t>     arg_out_peers = {"out-peers", "set max number of out peers", -1};
     const command_line::arg_descriptor<int> arg_tos_flag = {"tos-flag", "set TOS flag", -1};
 
     const command_line::arg_descriptor<int64_t> arg_limit_rate_up = {"limit-rate-up", "set limit-rate-up [kB/s]", -1};


### PR DESCRIPTION
Details, self-explanatory