### PR TITLE
wallet: guard against exception in process_blocks

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -701,7 +701,15 @@ void wallet2::refresh(uint64_t start_height, uint64_t & blocks_fetched, bool& re
       bool error = false;
       pull_thread = std::thread([&]{pull_next_blocks(start_height, next_blocks_start_height, short_chain_history, blocks, next_blocks, error);});
 
-      process_blocks(blocks_start_height, blocks, added_blocks);
+      try
+      {
+        process_blocks(blocks_start_height, blocks, added_blocks);
+      }
+      catch (...)
+      {
+        pull_thread.join();
+        throw;
+      }
       blocks_fetched += added_blocks;
       pull_thread.join();
       if(!added_blocks)


### PR DESCRIPTION
If an exception occurs, the thread needs to be joined, or it
will be deleted while still live, and terminate the process.