### PR TITLE
blockchain: revert handle_get_objects adding block id on tx not found

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1376,7 +1376,6 @@ bool Blockchain::handle_get_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, NO
                   << " transactions for block with hash: " << get_block_hash(bl)
                   << std::endl
             );
-            rsp.missed_ids.push_back(get_block_hash(bl));
 
             // append missed transaction hashes to response missed_ids field,
             // as done below if any standalone transactions were requested


### PR DESCRIPTION
This differs from the original CN code, and there seems to be
no reason to include the block itself, if it was found