### PR TITLE
new --software-aes command line flag

### DIFF
--- a/src/crypto/hash-ops.h
+++ b/src/crypto/hash-ops.h
@@ -78,6 +78,8 @@ enum {
   HASH_DATA_AREA = 136
 };
 
+void force_software_aes(bool sw);
+
 void cn_fast_hash(const void *data, size_t length, char *hash);
 void cn_slow_hash(const void *data, size_t length, char *hash);
 

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -37,6 +37,13 @@
 #include "hash-ops.h"
 #include "oaes_lib.h"
 
+static bool sw_aes = false;
+
+void force_software_aes(bool sw)
+{
+  sw_aes = sw;
+}
+
 #if defined(__x86_64__) || (defined(_MSC_VER) && defined(_WIN64))
 // Optimised code below, uses x86-specific intrinsics, SSE2, AES-NI
 // Fall back to more portable code is down at the bottom
@@ -509,7 +516,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash)
     size_t i, j;
     uint64_t *p = NULL;
     oaes_ctx *aes_ctx;
-    int useAes = check_aes_hw();
+    int useAes = !sw_aes && check_aes_hw();
 
     static void (*const extra_hashes[4])(const void *, size_t, char *) =
     {

--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -59,6 +59,11 @@ namespace daemon_args
     "os-version"
   , "OS for which this executable was compiled"
   };
+  const command_line::arg_descriptor<int> arg_software_aes = {
+    "software-aes"
+  , ""
+  , false
+  };
 }  // namespace daemon_args
 
 #endif // DAEMON_COMMAND_LINE_ARGS_H

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -81,6 +81,7 @@ int main(int argc, char const * argv[])
       bf::path default_log = default_data_dir / std::string(CRYPTONOTE_NAME ".log");
       command_line::add_arg(core_settings, daemon_args::arg_log_file, default_log.string());
       command_line::add_arg(core_settings, daemon_args::arg_log_level);
+      command_line::add_arg(core_settings, daemon_args::arg_software_aes);
 
       daemonizer::init_options(hidden_options, visible_options);
       daemonize::t_executor::init_options(core_settings);
@@ -238,6 +239,12 @@ int main(int argc, char const * argv[])
         gCurrentLogger.setDebugLevel(otshell_utils_log_level);
         LOG_PRINT_L0("LOG_LEVEL set to " << new_log_level);
       }
+    }
+
+    if (command_line::has_arg(vm, daemon_args::arg_software_aes))
+    {
+      LOG_PRINT_L1("Forcing software AES");
+      crypto::force_software_aes(true);
     }
 
     // log_file_path

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -95,6 +95,7 @@ namespace
   const command_line::arg_descriptor<bool> arg_testnet = {"testnet", sw::tr("For testnet. Daemon must also be launched with --testnet flag"), false};
   const command_line::arg_descriptor<bool> arg_restricted = {"restricted-rpc", sw::tr("Restricts RPC to view-only commands"), false};
   const command_line::arg_descriptor<bool> arg_trusted_daemon = {"trusted-daemon", sw::tr("Enable commands which rely on a trusted daemon"), false};
+  const command_line::arg_descriptor<bool> arg_software_aes = {"software-aes", "", false};
 
   const command_line::arg_descriptor< std::vector<std::string> > arg_command = {"command", ""};
 
@@ -2453,6 +2454,7 @@ int main(int argc, char* argv[])
   command_line::add_arg(desc_params, arg_daemon_port);
   command_line::add_arg(desc_params, arg_command);
   command_line::add_arg(desc_params, arg_log_level);
+  command_line::add_arg(desc_params, arg_software_aes);
 
   bf::path default_log {log_space::log_singletone::get_default_log_folder()};
   std::string log_file_name = log_space::log_singletone::get_default_log_file();
@@ -2538,6 +2540,11 @@ int main(int argc, char* argv[])
     );
 
   message_writer(epee::log_space::console_color_white, true) << "Monero '" << MONERO_RELEASE_NAME << "' (v" << MONERO_VERSION_FULL << ")";
+
+  if (command_line::has_arg(vm, arg_software_aes)) {
+    LOG_PRINT_L1("Forcing software AES");
+    crypto::force_software_aes(true);
+  }
 
   if(command_line::has_arg(vm, arg_log_level))
     log_level = command_line::get_arg(vm, arg_log_level);


### PR DESCRIPTION
Used to avoid AES-NI. Useful for working around a bug where
valgrind seems to break on some VMs