### PR TITLE
Move HardFork DB update to BlockchainDB::add_block()

### DIFF
--- a/src/blockchain_db/berkeleydb/db_bdb.cpp
+++ b/src/blockchain_db/berkeleydb/db_bdb.cpp
@@ -1831,6 +1831,21 @@ void BlockchainBDB::set_batch_transactions(bool batch_transactions)
     LOG_PRINT_L3("batch transactions " << (m_batch_transactions ? "enabled" : "disabled"));
 }
 
+void BlockchainBDB::block_txn_start()
+{
+  // TODO
+}
+
+void BlockchainBDB::block_txn_stop()
+{
+  // TODO
+}
+
+void BlockchainBDB::block_txn_abort()
+{
+  // TODO
+}
+
 uint64_t BlockchainBDB::add_block(const block& blk, const size_t& block_size, const difficulty_type& cumulative_difficulty, const uint64_t& coins_generated, const std::vector<transaction>& txs)
 {
     LOG_PRINT_L3("BlockchainBDB::" << __func__);

--- a/src/blockchain_db/berkeleydb/db_bdb.cpp
+++ b/src/blockchain_db/berkeleydb/db_bdb.cpp
@@ -781,6 +781,8 @@ BlockchainBDB::BlockchainBDB(bool batch_transactions) :
     m_batch_transactions = batch_transactions;
     m_write_txn = nullptr;
     m_height = 0;
+
+    m_hardfork = nullptr;
 }
 
 void BlockchainBDB::open(const std::string& filename, const int db_flags)

--- a/src/blockchain_db/berkeleydb/db_bdb.h
+++ b/src/blockchain_db/berkeleydb/db_bdb.h
@@ -328,6 +328,10 @@ public:
   virtual void batch_stop();
   virtual void batch_abort();
 
+  virtual void block_txn_start();
+  virtual void block_txn_stop();
+  virtual void block_txn_abort();
+
   virtual void pop_block(block& blk, std::vector<transaction>& txs);
 
 #if defined(BDB_BULK_CAN_THREAD)

--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -138,6 +138,11 @@ uint64_t BlockchainDB::add_block( const block& blk
   return prev_height;
 }
 
+void BlockchainDB::set_hard_fork(HardFork*& hf)
+{
+  m_hardfork = hf;
+}
+
 void BlockchainDB::pop_block(block& blk, std::vector<transaction>& txs)
 {
   blk = get_top_block();

--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -130,6 +130,7 @@ uint64_t BlockchainDB::add_block( const block& blk
   // DB's new height based on this added block is only incremented after this
   // function returns, so height() here returns the new previous height.
   uint64_t prev_height = height();
+  m_hardfork->add(blk, prev_height);
 
   block_txn_stop();
 

--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -99,6 +99,8 @@ uint64_t BlockchainDB::add_block( const block& blk
                                 , const std::vector<transaction>& txs
                                 )
 {
+  block_txn_start();
+
   TIME_MEASURE_START(time1);
   crypto::hash blk_hash = get_block_hash(blk);
   TIME_MEASURE_FINISH(time1);
@@ -125,9 +127,15 @@ uint64_t BlockchainDB::add_block( const block& blk
   TIME_MEASURE_FINISH(time1);
   time_add_transaction += time1;
 
+  // DB's new height based on this added block is only incremented after this
+  // function returns, so height() here returns the new previous height.
+  uint64_t prev_height = height();
+
+  block_txn_stop();
+
   ++num_calls;
 
-  return height();
+  return prev_height;
 }
 
 void BlockchainDB::pop_block(block& blk, std::vector<transaction>& txs)

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -28,12 +28,15 @@
 #ifndef BLOCKCHAIN_DB_H
 #define BLOCKCHAIN_DB_H
 
+#pragma once
+
 #include <list>
 #include <string>
 #include <exception>
 #include "crypto/hash.h"
 #include "cryptonote_core/cryptonote_basic.h"
 #include "cryptonote_core/difficulty.h"
+#include "cryptonote_core/hardfork.h"
 
 /* DB Driver Interface
  *
@@ -322,6 +325,8 @@ protected:
   uint64_t time_commit1 = 0;
   bool m_auto_remove_logs = true;
 
+  HardFork* m_hardfork;
+
 public:
 
   // virtual dtor
@@ -371,6 +376,8 @@ public:
   virtual void block_txn_start() = 0;
   virtual void block_txn_stop() = 0;
   virtual void block_txn_abort() = 0;
+
+  virtual void set_hard_fork(HardFork*& hf);
 
   // adds a block with the given metadata to the top of the blockchain, returns the new height
   // NOTE: subclass implementations of this (or the functions it calls) need

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -368,6 +368,10 @@ public:
   virtual void batch_stop() = 0;
   virtual void set_batch_transactions(bool) = 0;
 
+  virtual void block_txn_start() = 0;
+  virtual void block_txn_stop() = 0;
+  virtual void block_txn_abort() = 0;
+
   // adds a block with the given metadata to the top of the blockchain, returns the new height
   // NOTE: subclass implementations of this (or the functions it calls) need
   // to handle undoing any partially-added blocks in the event of a failure.

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -2507,14 +2507,14 @@ void BlockchainLMDB::set_hard_fork_starting_height(uint8_t version, uint64_t hei
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   check_open();
 
-  TXN_PREFIX(0);
+  TXN_BLOCK_PREFIX(0);
 
   MDB_val_copy<uint8_t> val_key(version);
   MDB_val_copy<uint64_t> val_value(height);
   if (auto result = mdb_put(*txn_ptr, m_hf_starting_heights, &val_key, &val_value, 0))
     throw1(DB_ERROR(std::string("Error adding hard fork starting height to db transaction: ").append(mdb_strerror(result)).c_str()));
 
-  TXN_POSTFIX_SUCCESS();
+  TXN_BLOCK_POSTFIX_SUCCESS();
 }
 
 uint64_t BlockchainLMDB::get_hard_fork_starting_height(uint8_t version) const
@@ -2542,14 +2542,14 @@ void BlockchainLMDB::set_hard_fork_version(uint64_t height, uint8_t version)
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   check_open();
 
-  TXN_PREFIX(0);
+  TXN_BLOCK_PREFIX(0);
 
   MDB_val_copy<uint64_t> val_key(height);
   MDB_val_copy<uint8_t> val_value(version);
   if (auto result = mdb_put(*txn_ptr, m_hf_versions, &val_key, &val_value, 0))
     throw1(DB_ERROR(std::string("Error adding hard fork version to db transaction: ").append(mdb_strerror(result)).c_str()));
 
-  TXN_POSTFIX_SUCCESS();
+  TXN_BLOCK_POSTFIX_SUCCESS();
 }
 
 uint8_t BlockchainLMDB::get_hard_fork_version(uint64_t height) const

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -945,6 +945,8 @@ BlockchainLMDB::BlockchainLMDB(bool batch_transactions)
   m_write_batch_txn = nullptr;
   m_batch_active = false;
   m_height = 0;
+
+  m_hardfork = nullptr;
 }
 
 void BlockchainLMDB::open(const std::string& filename, const int mdb_flags)

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -194,6 +194,10 @@ public:
   virtual void batch_stop();
   virtual void batch_abort();
 
+  virtual void block_txn_start();
+  virtual void block_txn_stop();
+  virtual void block_txn_abort();
+
   virtual void pop_block(block& blk, std::vector<transaction>& txs);
 
   virtual bool can_thread_bulk_indices() const { return true; }

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -400,11 +400,8 @@ int import_from_file(FakeCore& simple_core, const std::string& import_file_path,
             // size_t blob_size = 0;
             // get_transaction_hash(tx, hsh, blob_size);
 
-            // we'd need to get the starting heights from the daemon
-            // to be correct once voting kicks in
-            uint64_t v2height = opt_testnet ? 624634 : 1009827;
 
-            uint8_t version = h < v2height ? 1 : 2;
+            uint8_t version = simple_core.m_storage.get_current_hard_fork_version();
             tx_verification_context tvc = AUTO_VAL_INIT(tvc);
             bool r = true;
             r = simple_core.m_pool.add_tx(tx, tvc, true, true, version);

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -469,9 +469,6 @@ int import_from_file(FakeCore& simple_core, const std::string& import_file_path,
           try
           {
             simple_core.add_block(b, block_size, cumulative_difficulty, coins_generated, txs);
-            #if !defined(BLOCKCHAIN_DB) || (BLOCKCHAIN_DB == DB_LMDB)
-            simple_core.m_hardfork->add(b, h-1);
-            #endif
           }
           catch (const std::exception& e)
           {

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2692,9 +2692,6 @@ bool Blockchain::handle_block_to_main_chain(const block& bl, const crypto::hash&
 
   TIME_MEASURE_FINISH(addblock);
 
-  // this will not fail since check succeeded above
-  m_hardfork->add(bl, new_height - 1);
-
   // do this after updating the hard fork state since the size limit may change due to fork
   update_next_cumulative_size_limit();
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -290,6 +290,8 @@ bool Blockchain::init(BlockchainDB* db, const bool testnet, const bool fakechain
   }
   m_hardfork->init();
 
+  m_db->set_hard_fork(m_hardfork);
+
   // if the blockchain is new, add the genesis block
   // this feels kinda kludgy to do it this way, but can be looked at later.
   // TODO: add function to create and store genesis block,

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -461,6 +461,11 @@ block Blockchain::pop_block_from_blockchain()
     {
       cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);
 
+      // FIXME: HardFork
+      // Besides the below, popping a block should also remove the last entry
+      // in hf_versions.
+      //
+      // FIXME: HardFork
       // This is not quite correct, as we really want to add the txes
       // to the pool based on the version determined after all blocks
       // are popped.


### PR DESCRIPTION
Move HardFork DB update to BlockchainDB::add_block()

Ensures the database is consistent.
    
Also simplifes blockchain_import in that verify mode off has less to work around.
