### PR TITLE
blockchain_import: Add BerkeleyDB support

### DIFF
--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -78,6 +78,17 @@ using namespace cryptonote;
 using namespace epee;
 
 
+std::string join_set_strings(const std::unordered_set<std::string>& db_types_all, const char* delim)
+{
+  std::string result;
+  std::ostringstream s;
+  std::copy(db_types_all.begin(), db_types_all.end(), std::ostream_iterator<std::string>(s, delim));
+  result = s.str();
+  if (result.length() > 0)
+    result.erase(result.end()-strlen(delim), result.end());
+  return result;
+}
+
 // db_type: lmdb, berkeley
 // db_mode: safe, fast, fastest
 int get_db_flags_from_mode(const std::string& db_type, const std::string& db_mode)
@@ -611,6 +622,9 @@ int main(int argc, char* argv[])
   std::unordered_set<std::string> db_types_all = cryptonote::blockchain_db_types;
   db_types_all.insert("memory");
 
+  std::string available_dbs = join_set_strings(db_types_all, ", ");
+  available_dbs = "available: " + available_dbs;
+
   uint32_t log_level = LOG_LEVEL_0;
   uint64_t num_blocks = 0;
   uint64_t block_stop = 0;
@@ -642,8 +656,7 @@ int main(int argc, char* argv[])
       , false
   };
   const command_line::arg_descriptor<std::string> arg_database = {
-    "database", "available: memory, lmdb, berkeley"
-      , default_db_type
+    "database", available_dbs.c_str(), default_db_type
   };
   const command_line::arg_descriptor<bool> arg_verify =  {"verify",
     "Verify blocks and transactions during import", true};

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -724,7 +724,7 @@ int main(int argc, char* argv[])
 #if !defined(BLOCKCHAIN_DB)
   if (db_type == "lmdb")
   {
-    fake_core_db simple_core(m_config_folder, opt_testnet, opt_batch, db_flags);
+    fake_core_db simple_core(m_config_folder, opt_testnet, opt_batch, db_type, db_flags);
     import_from_file(simple_core, import_file_path, block_stop);
   }
   else if (db_type == "memory")
@@ -746,7 +746,7 @@ int main(int argc, char* argv[])
     return 1;
   }
 #if BLOCKCHAIN_DB == DB_LMDB
-  fake_core_db simple_core(m_config_folder, opt_testnet, opt_batch, db_flags);
+  fake_core_db simple_core(m_config_folder, opt_testnet, opt_batch, db_type, db_flags);
 #else
   fake_core_memory simple_core(m_config_folder, opt_testnet);
 #endif

--- a/src/blockchain_utilities/fake_core.h
+++ b/src/blockchain_utilities/fake_core.h
@@ -57,10 +57,10 @@ struct fake_core_db
 
   // for multi_db_runtime:
 #if !defined(BLOCKCHAIN_DB)
-  fake_core_db(const boost::filesystem::path &path, const bool use_testnet=false, const bool do_batch=true, const int db_flags=0) : m_pool(&m_storage), m_storage(m_pool)
+  fake_core_db(const boost::filesystem::path &path, const bool use_testnet=false, const bool do_batch=true, const std::string& db_type="lmdb", const int db_flags=0) : m_pool(&m_storage), m_storage(m_pool)
   // for multi_db_compile:
 #else
-  fake_core_db(const boost::filesystem::path &path, const bool use_testnet=false, const bool do_batch=true, const int db_flags=0) : m_pool(m_storage), m_storage(m_pool)
+  fake_core_db(const boost::filesystem::path &path, const bool use_testnet=false, const bool do_batch=true, const std::string& db_type="lmdb", const int db_flags=0) : m_pool(m_storage), m_storage(m_pool)
 #endif
   {
     m_pool.init(path.string());

--- a/src/blockchain_utilities/fake_core.h
+++ b/src/blockchain_utilities/fake_core.h
@@ -33,6 +33,7 @@
 #include "cryptonote_core/blockchain_storage.h" // in-memory DB
 #include "blockchain_db/blockchain_db.h"
 #include "blockchain_db/lmdb/db_lmdb.h"
+#include "blockchain_db/berkeleydb/db_bdb.h"
 
 using namespace cryptonote;
 
@@ -65,7 +66,18 @@ struct fake_core_db
   {
     m_pool.init(path.string());
 
-    BlockchainDB* db = new BlockchainLMDB();
+    BlockchainDB* db = nullptr;
+    if (db_type == "lmdb")
+      db = new BlockchainLMDB();
+#if defined(BERKELEY_DB)
+    else if (db_type == "berkeley")
+      db = new BlockchainBDB();
+#endif
+    else
+    {
+      LOG_ERROR("Attempted to use non-existent database type: " << db_type);
+      throw std::runtime_error("Attempting to use non-existent database type");
+    }
 
     boost::filesystem::path folder(path);
 

--- a/src/blockchain_utilities/fake_core.h
+++ b/src/blockchain_utilities/fake_core.h
@@ -47,7 +47,7 @@ namespace
 
 #if !defined(BLOCKCHAIN_DB) || BLOCKCHAIN_DB == DB_LMDB
 
-struct fake_core_lmdb
+struct fake_core_db
 {
   Blockchain m_storage;
   HardFork* m_hardfork = nullptr;
@@ -57,10 +57,10 @@ struct fake_core_lmdb
 
   // for multi_db_runtime:
 #if !defined(BLOCKCHAIN_DB)
-  fake_core_lmdb(const boost::filesystem::path &path, const bool use_testnet=false, const bool do_batch=true, const int mdb_flags=0) : m_pool(&m_storage), m_storage(m_pool)
+  fake_core_db(const boost::filesystem::path &path, const bool use_testnet=false, const bool do_batch=true, const int db_flags=0) : m_pool(&m_storage), m_storage(m_pool)
   // for multi_db_compile:
 #else
-  fake_core_lmdb(const boost::filesystem::path &path, const bool use_testnet=false, const bool do_batch=true, const int mdb_flags=0) : m_pool(m_storage), m_storage(m_pool)
+  fake_core_db(const boost::filesystem::path &path, const bool use_testnet=false, const bool do_batch=true, const int db_flags=0) : m_pool(m_storage), m_storage(m_pool)
 #endif
   {
     m_pool.init(path.string());
@@ -76,7 +76,7 @@ struct fake_core_lmdb
     const std::string filename = folder.string();
     try
     {
-      db->open(filename, mdb_flags);
+      db->open(filename, db_flags);
     }
     catch (const std::exception& e)
     {
@@ -96,7 +96,7 @@ struct fake_core_lmdb
     support_batch = true;
     support_add_block = true;
   }
-  ~fake_core_lmdb()
+  ~fake_core_db()
   {
     m_storage.get_db().check_hard_fork_info();
     m_storage.deinit();


### PR DESCRIPTION
Sample usage:

blockchain_import --database berkeley
blockchain_import --database berkeley#txn_nosync

Alternatively, the optional DB flags for both LMDB and BerkeleyDB can be replaced by a composite mode, which matches those optionally provided as part of the daemon's --db-type argument ("safe", "fast", "fastest").

blockchain_import --database berkeley#fastest

Argument after the # is interpreted as a composite mode if there's only one (no comma separated arguments).

More examples:

blockchain_import --database lmdb#fast

blockchain_import --database berkeley#fast

Multiple specific DB flags are still supported, e.g.

blockchain_import --database lmdb#nosync,nordahead

blockchain_import --database berkeley#txn_nosync