### PR TITLE
blockchain_import: Check bit width for more than just WIN32

### DIFF
--- a/src/blockchain_utilities/CMakeLists.txt
+++ b/src/blockchain_utilities/CMakeLists.txt
@@ -99,6 +99,11 @@ target_link_libraries(blockchain_converter
 	blockchain_db
     ${CMAKE_THREAD_LIBS_INIT})
 
+if(${ARCH_WIDTH} EQUAL 32)
+  target_compile_definitions(blockchain_converter
+    PUBLIC -DARCH_WIDTH=32)
+endif()
+
 add_dependencies(blockchain_converter
 	version)
 set_property(TARGET blockchain_converter
@@ -116,6 +121,11 @@ target_link_libraries(blockchain_import
 	blockchain_db
 	p2p
     ${CMAKE_THREAD_LIBS_INIT})
+
+if(${ARCH_WIDTH} EQUAL 32)
+  target_compile_definitions(blockchain_import
+    PUBLIC -DARCH_WIDTH=32)
+endif()
 
 add_dependencies(blockchain_import
 	version)

--- a/src/blockchain_utilities/blockchain_converter.cpp
+++ b/src/blockchain_utilities/blockchain_converter.cpp
@@ -57,12 +57,12 @@ bool opt_testnet = false;
 
 // number of blocks per batch transaction
 // adjustable through command-line argument according to available RAM
-#if !defined(WIN32)
+#if ARCH_WIDTH != 32
 uint64_t db_batch_size_verify = 5000;
 #else
 // set a lower default batch size for Windows, pending possible LMDB issue with
 // large batch size.
-uint64_t db_batch_size_verify = 1000;
+uint64_t db_batch_size_verify = 100;
 #endif
 
 // converter only uses verify mode

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -56,11 +56,11 @@ bool opt_testnet = true;
 
 // number of blocks per batch transaction
 // adjustable through command-line argument according to available RAM
-#if !defined(WIN32)
+#if ARCH_WIDTH != 32
 uint64_t db_batch_size = 20000;
 #else
 // set a lower default batch size, pending possible LMDB issue with large transaction size
-uint64_t db_batch_size = 1000;
+uint64_t db_batch_size = 100;
 #endif
 
 // when verifying, use a smaller default batch size so progress is more


### PR DESCRIPTION
Pass the CMake bit width setting to compile flags for blockchain_import
and blockchain_converter.

For LMDB on 32-bit, hyc has found that batch size of 100 appears to be a
good default.