### PR TITLE
move g_test_dbg_lock_sleep from a global to a function level static

### DIFF
--- a/contrib/epee/include/syncobj.h
+++ b/contrib/epee/include/syncobj.h
@@ -39,7 +39,14 @@
 namespace epee
 {
 
-  extern unsigned int g_test_dbg_lock_sleep;
+  namespace debug
+  {
+    inline unsigned int &g_test_dbg_lock_sleep()
+    {
+      static unsigned int value = 0;
+      return value;
+    }
+  }
   
   struct simple_event
   {
@@ -217,10 +224,10 @@ namespace epee
 #define  SHARED_CRITICAL_REGION_BEGIN(x) { shared_guard   critical_region_var(x)
 #define  EXCLUSIVE_CRITICAL_REGION_BEGIN(x) { exclusive_guard   critical_region_var(x)
 
-#define  CRITICAL_REGION_LOCAL(x) {std::this_thread::sleep_for(std::chrono::milliseconds(epee::g_test_dbg_lock_sleep));}   epee::critical_region_t<decltype(x)>   critical_region_var(x)
-#define  CRITICAL_REGION_BEGIN(x) { std::this_thread::sleep_for(std::chrono::milliseconds(epee::g_test_dbg_lock_sleep)); epee::critical_region_t<decltype(x)>   critical_region_var(x)
-#define  CRITICAL_REGION_LOCAL1(x) {std::this_thread::sleep_for(std::chrono::milliseconds(epee::g_test_dbg_lock_sleep));} epee::critical_region_t<decltype(x)>   critical_region_var1(x)
-#define  CRITICAL_REGION_BEGIN1(x) {  std::this_thread::sleep_for(std::chrono::milliseconds(epee::g_test_dbg_lock_sleep)); epee::critical_region_t<decltype(x)>   critical_region_var1(x)
+#define  CRITICAL_REGION_LOCAL(x) {std::this_thread::sleep_for(std::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep()));}   epee::critical_region_t<decltype(x)>   critical_region_var(x)
+#define  CRITICAL_REGION_BEGIN(x) { std::this_thread::sleep_for(std::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep())); epee::critical_region_t<decltype(x)>   critical_region_var(x)
+#define  CRITICAL_REGION_LOCAL1(x) {std::this_thread::sleep_for(std::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep()));} epee::critical_region_t<decltype(x)>   critical_region_var1(x)
+#define  CRITICAL_REGION_BEGIN1(x) {  std::this_thread::sleep_for(std::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep())); epee::critical_region_t<decltype(x)>   critical_region_var1(x)
 
 #define  CRITICAL_REGION_END() }
 

--- a/src/blockchain_utilities/blockchain_converter.cpp
+++ b/src/blockchain_utilities/blockchain_converter.cpp
@@ -45,8 +45,6 @@
 #include <iostream>
 
 
-unsigned int epee::g_test_dbg_lock_sleep = 0;
-
 namespace
 {
 

--- a/src/blockchain_utilities/blockchain_dump.cpp
+++ b/src/blockchain_utilities/blockchain_dump.cpp
@@ -38,8 +38,6 @@
 #include "common/command_line.h"
 #include "version.h"
 
-unsigned int epee::g_test_dbg_lock_sleep = 0;
-
 namespace po = boost::program_options;
 using namespace epee; // log_space
 

--- a/src/blockchain_utilities/blockchain_export.cpp
+++ b/src/blockchain_utilities/blockchain_export.cpp
@@ -31,8 +31,6 @@
 #include "common/command_line.h"
 #include "version.h"
 
-unsigned int epee::g_test_dbg_lock_sleep = 0;
-
 namespace po = boost::program_options;
 using namespace epee; // log_space
 

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -44,8 +44,6 @@
 
 #include "fake_core.h"
 
-unsigned int epee::g_test_dbg_lock_sleep = 0;
-
 namespace
 {
 // CONFIG

--- a/src/blockchain_utilities/cn_deserialize.cpp
+++ b/src/blockchain_utilities/cn_deserialize.cpp
@@ -32,8 +32,6 @@
 #include "common/command_line.h"
 #include "version.h"
 
-unsigned int epee::g_test_dbg_lock_sleep = 0;
-
 namespace po = boost::program_options;
 using namespace epee; // log_space
 

--- a/src/connectivity_tool/conn_tool.cpp
+++ b/src/connectivity_tool/conn_tool.cpp
@@ -49,8 +49,6 @@ namespace po = boost::program_options;
 using namespace cryptonote;
 using namespace nodetool;
 
-unsigned int epee::g_test_dbg_lock_sleep = 0;
-
 namespace
 {
   const command_line::arg_descriptor<std::string, true> arg_ip           = {"ip", "set ip"};

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -46,8 +46,6 @@ using namespace epee;
 
 #include <functional>
 
-unsigned int epee::g_test_dbg_lock_sleep = 0;
-
 namespace daemonize {
 
 struct t_internals {

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -132,7 +132,7 @@ int main(int argc, char const * argv[])
       return 0;
     }
 
-    epee::g_test_dbg_lock_sleep = command_line::get_arg(vm, command_line::arg_test_dbg_lock_sleep);
+    epee::debug::g_test_dbg_lock_sleep() = command_line::get_arg(vm, command_line::arg_test_dbg_lock_sleep);
 
     std::string db_type = command_line::get_arg(vm, command_line::arg_db_type);
 

--- a/src/miner/simpleminer.cpp
+++ b/src/miner/simpleminer.cpp
@@ -41,7 +41,6 @@
 
 using namespace epee;
 namespace po = boost::program_options;
-unsigned int epee::g_test_dbg_lock_sleep = 0;
 
 int main(int argc, char** argv)
 {

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -73,8 +73,6 @@ typedef cryptonote::simple_wallet sw;
 
 #define EXTENDED_LOGS_FILE "wallet_details.log"
 
-unsigned int epee::g_test_dbg_lock_sleep = 0;
-
 #define DEFAULT_MIX 4
 
 namespace

--- a/tests/core_proxy/core_proxy.cpp
+++ b/tests/core_proxy/core_proxy.cpp
@@ -62,8 +62,6 @@ using namespace crypto;
 
 BOOST_CLASS_VERSION(nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<tests::proxy_core> >, 1);
 
-unsigned int epee::g_test_dbg_lock_sleep = 0;
-
 int main(int argc, char* argv[])
 {
 

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -44,8 +44,6 @@ namespace
   const command_line::arg_descriptor<bool>        arg_test_transactions           = {"test_transactions", ""};
 }
 
-unsigned int epee::g_test_dbg_lock_sleep = 0;
-
 int main(int argc, char* argv[])
 {
   TRY_ENTRY();

--- a/tests/functional_tests/main.cpp
+++ b/tests/functional_tests/main.cpp
@@ -55,8 +55,6 @@ namespace
   const command_line::arg_descriptor<size_t> arg_test_repeat_count = {"test_repeat_count", "", 1};
 }
 
-unsigned int epee::g_test_dbg_lock_sleep = 0;
-
 int main(int argc, char* argv[])
 {
   TRY_ENTRY();

--- a/tests/net_load_tests/clt.cpp
+++ b/tests/net_load_tests/clt.cpp
@@ -628,8 +628,6 @@ TEST_F(net_load_test_clt, permament_open_and_close_and_connections_closed_by_ser
   ASSERT_EQ(RESERVED_CONN_CNT, m_tcp_server.get_config_object().get_connections_count());
 }
 
-unsigned int epee::g_test_dbg_lock_sleep = 0;
-
 int main(int argc, char** argv)
 {
   epee::debug::get_set_enable_assert(true, false);

--- a/tests/net_load_tests/srv.cpp
+++ b/tests/net_load_tests/srv.cpp
@@ -213,8 +213,6 @@ namespace
   };
 }
 
-unsigned int epee::g_test_dbg_lock_sleep = 0;
-
 int main(int argc, char** argv)
 {
   //set up logging options

--- a/tests/performance_tests/main.cpp
+++ b/tests/performance_tests/main.cpp
@@ -42,8 +42,6 @@
 #include "generate_key_image_helper.h"
 #include "is_out_to_acc.h"
 
-unsigned int epee::g_test_dbg_lock_sleep = 0;
-
 int main(int argc, char** argv)
 {
   set_process_affinity(1);

--- a/tests/unit_tests/main.cpp
+++ b/tests/unit_tests/main.cpp
@@ -32,8 +32,6 @@
 
 #include "include_base_utils.h"
 
-unsigned int epee::g_test_dbg_lock_sleep = 0;
-
 int main(int argc, char** argv)
 {
   epee::debug::get_set_enable_assert(true, false);


### PR DESCRIPTION
This avoids the need to define that variable in every program
which uses epee.