### PR TITLE
simplewallet: add a new --restore-from-keys option

### DIFF
--- a/src/cryptonote_core/account.cpp
+++ b/src/cryptonote_core/account.cpp
@@ -93,9 +93,10 @@ DISABLE_VS_WARNINGS(4244 4345)
     return first;
   }
   //-----------------------------------------------------------------
-  void account_base::create_from_viewkey(const cryptonote::account_public_address& address, const crypto::secret_key& viewkey)
+  void account_base::create_from_keys(const cryptonote::account_public_address& address, const crypto::secret_key& spendkey, const crypto::secret_key& viewkey)
   {
     m_keys.m_account_address = address;
+    m_keys.m_spend_secret_key = spendkey;
     m_keys.m_view_secret_key = viewkey;
 
     struct tm timestamp;
@@ -107,6 +108,13 @@ DISABLE_VS_WARNINGS(4244 4345)
     timestamp.tm_sec = 0;
 
     m_creation_timestamp = mktime(&timestamp);
+  }
+  //-----------------------------------------------------------------
+  void account_base::create_from_viewkey(const cryptonote::account_public_address& address, const crypto::secret_key& viewkey)
+  {
+    crypto::secret_key fake;
+    memset(&fake, 0, sizeof(fake));
+    create_from_keys(address, fake, viewkey);
   }
   //-----------------------------------------------------------------
   const account_keys& account_base::get_keys() const

--- a/src/cryptonote_core/account.h
+++ b/src/cryptonote_core/account.h
@@ -58,6 +58,7 @@ namespace cryptonote
   public:
     account_base();
     crypto::secret_key generate(const crypto::secret_key& recovery_key = crypto::secret_key(), bool recover = false, bool two_random = false);
+    void create_from_keys(const cryptonote::account_public_address& address, const crypto::secret_key& spendkey, const crypto::secret_key& viewkey);
     void create_from_viewkey(const cryptonote::account_public_address& address, const crypto::secret_key& viewkey);
     const account_keys& get_keys() const;
     std::string get_public_address_str(bool testnet) const;

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -83,6 +83,8 @@ namespace cryptonote
     bool new_wallet(const std::string &wallet_file, const std::string& password, const crypto::secret_key& recovery_key,
         bool recover, bool two_random, bool testnet, const std::string &old_language);
     bool new_wallet(const std::string &wallet_file, const std::string& password, const cryptonote::account_public_address& address,
+        const crypto::secret_key& spendkey, const crypto::secret_key& viewkey, bool testnet);
+    bool new_wallet(const std::string &wallet_file, const std::string& password, const cryptonote::account_public_address& address,
         const crypto::secret_key& viewkey, bool testnet);
     bool open_wallet(const std::string &wallet_file, const std::string& password, bool testnet);
     bool close_wallet();
@@ -218,6 +220,7 @@ namespace cryptonote
     std::string m_wallet_file;
     std::string m_generate_new;
     std::string m_generate_from_view_key;
+    std::string m_generate_from_keys;
     std::string m_import_path;
 
     std::string m_electrum_seed;  // electrum-style seed parameter

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -185,6 +185,16 @@ namespace tools
       const crypto::secret_key& recovery_param = crypto::secret_key(), bool recover = false,
       bool two_random = false);
     /*!
+     * \brief Creates a wallet from a public address and a spend/view secret key pair.
+     * \param  wallet_        Name of wallet file
+     * \param  password       Password of wallet file
+     * \param  viewkey        view secret key
+     * \param  spendkey       spend secret key
+     */
+    void generate(const std::string& wallet, const std::string& password,
+      const cryptonote::account_public_address &account_public_address,
+      const crypto::secret_key& spendkey, const crypto::secret_key& viewkey);
+    /*!
      * \brief Creates a watch only wallet from a public address and a view secret key.
      * \param  wallet_        Name of wallet file
      * \param  password       Password of wallet file


### PR DESCRIPTION
It is similar in use to --restore-from-view-key, but also expects
a spend private key.

Requested by luigi1112, and useful to restore MyMonero wallets.