### PR TITLE
simplewallet: special ^C handling for windows

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2746,7 +2746,11 @@ int main(int argc, char* argv[])
     else
     {
       tools::signal_handler::install([&w](int type) {
+#ifdef WIN32
+        if (type == CTRL_C_EVENT)
+#else
         if (type == SIGINT)
+#endif
         {
           // if we're pressing ^C when refreshing, just stop refreshing
           w.interrupt();


### PR DESCRIPTION
Because obviously it doesn't work as other POSIX platforms.

Reported and tested by luigi1111.