### PR TITLE
simplewallet: fix hang when setting auto-refresh to 0

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -450,6 +450,7 @@ bool simple_wallet::set_auto_refresh(const std::vector<std::string> &args/* = st
   else if (!auto_refresh && m_auto_refresh_run.load(std::memory_order_relaxed))
   {
     m_auto_refresh_run.store(false, std::memory_order_relaxed);
+    m_wallet->stop();
     m_auto_refresh_thread.join();
   }
 


### PR DESCRIPTION
It would try to join the auto refresh thread, which would
only happen after it was done, which would take a long time
when doing so on a newly created wallet.