### PR TITLE
Add destructor for readtxns

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -115,7 +115,7 @@ typedef struct mdb_threadinfo
 
 struct mdb_txn_safe
 {
-  mdb_txn_safe();
+  mdb_txn_safe(const bool check=true);
   ~mdb_txn_safe();
 
   void commit(std::string message = "");
@@ -142,8 +142,10 @@ struct mdb_txn_safe
   static void wait_no_active_txns();
   static void allow_new_txns();
 
+  mdb_threadinfo* m_tinfo;
   MDB_txn* m_txn;
   bool m_batch_txn = false;
+  bool m_check;
   static std::atomic<uint64_t> num_active_txns;
 
   // could use a mutex here, but this should be sufficient.


### PR DESCRIPTION
Only if we created the readtxn. Was missing cleanups from exceptions before.