### PR TITLE
tests: enable core tests again

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,7 +54,7 @@ else ()
   endif()
 endif ()
 
-#add_subdirectory(core_tests)
+add_subdirectory(core_tests)
 add_subdirectory(crypto)
 add_subdirectory(functional_tests)
 add_subdirectory(performance_tests)


### PR DESCRIPTION
They should not have been disabled in the first place