### PR TITLE
tests: add test for needed OpenSSL algorithms in unbound

### DIFF
--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -49,7 +49,8 @@ set(unit_tests_sources
   test_format_utils.cpp
   test_peerlist.cpp
   test_protocol_pack.cpp
-  hardfork.cpp)
+  hardfork.cpp
+  unbound.cpp)
 
 set(unit_tests_headers
   unit_tests_utils.h)
@@ -69,6 +70,7 @@ target_link_libraries(unit_tests
     ${Boost_REGEX_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}
+    ${UNBOUND_LIBRARIES}
     ${EXTRA_LIBRARIES})
 set_property(TARGET unit_tests
   PROPERTY

--- a/tests/unit_tests/unbound.cpp
+++ b/tests/unit_tests/unbound.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2016, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
+
+#include "gtest/gtest.h"
+
+extern "C" int dnskey_algo_id_is_supported(int);
+
+TEST(unbound, supported_algorithms)
+{
+  // Monero causes these to be tried, but we don't have access
+  // to this internal unbound header here, so we use raw numbers
+  // LDNS_RSASHA1            = 5,
+  // LDNS_RSASHA1_NSEC3      = 7,
+  // LDNS_RSASHA256          = 8,   /* RFC 5702 */
+  // LDNS_ECDSAP256SHA256    = 13,  /* RFC 6605 */
+
+  ASSERT_TRUE(dnskey_algo_id_is_supported(5));
+  ASSERT_TRUE(dnskey_algo_id_is_supported(7));
+  ASSERT_TRUE(dnskey_algo_id_is_supported(8));
+  ASSERT_TRUE(dnskey_algo_id_is_supported(13));
+}
+


### PR DESCRIPTION
These can be compiled out of libunbound, leading to failure
to check DNSSEC validity.