### PR TITLE
core: keep the acc loop for the genesis block

### DIFF
--- a/src/cryptonote_core/cryptonote_format_utils.cpp
+++ b/src/cryptonote_core/cryptonote_format_utils.cpp
@@ -145,7 +145,19 @@ namespace cryptonote
       [&out_amounts](uint64_t a_dust) { out_amounts.push_back(a_dust); });
 
     CHECK_AND_ASSERT_MES(1 <= max_outs, false, "max_out must be non-zero");
-    CHECK_AND_ASSERT_MES(max_outs >= out_amounts.size(), false, "max_out exceeded");
+    if (height == 0)
+    {
+      // the genesis block was not decomposed, for unknown reasons
+      while (max_outs < out_amounts.size())
+      {
+        out_amounts[out_amounts.size() - 2] += out_amounts.back();
+        out_amounts.resize(out_amounts.size() - 1);
+      }
+    }
+    else
+    {
+      CHECK_AND_ASSERT_MES(max_outs >= out_amounts.size(), false, "max_out exceeded");
+    }
 
     uint64_t summary_amounts = 0;
     for (size_t no = 0; no < out_amounts.size(); no++)


### PR DESCRIPTION
For unknown reasons, it was generated with a block reward
consisting of a single large dusty output.