### PR TITLE
epee: flush output after a message

### DIFF
--- a/contrib/epee/include/misc_log_ex.h
+++ b/contrib/epee/include/misc_log_ex.h
@@ -424,6 +424,7 @@ namespace log_space
       }
 
       std::cout << buf;
+      std::cout << std::flush;
 #endif
       reset_console_color();
       return  true;


### PR DESCRIPTION
This is equivalent to line buffering, as C++ seems to lack
a setvbuf equivalent which alows line buffering.