### PR TITLE
Fix get_tick_count() on Windows

### DIFF
--- a/contrib/epee/include/misc_os_dependent.h
+++ b/contrib/epee/include/misc_os_dependent.h
@@ -53,11 +53,13 @@ namespace misc_utils
 #if defined(_MSC_VER)
                 return ::GetTickCount64();
 #elif defined(WIN32)
-# if defined(WIN64)
-                return GetTickCount64();
-# else
-                return GetTickCount();
-# endif
+                static LARGE_INTEGER pcfreq = {0};
+                LARGE_INTEGER ticks;
+                if (!pcfreq.QuadPart)
+                    QueryPerformanceFrequency(&pcfreq);
+                QueryPerformanceCounter(&ticks);
+                ticks.QuadPart *= 1000; /* we want msec */
+                return ticks.QuadPart / pcfreq.QuadPart;
 #elif defined(__MACH__)
                 clock_serv_t cclock;
                 mach_timespec_t mts;


### PR DESCRIPTION
GetTickCount used in 52056dcfc480a126e06afaf209b1772b6aa77fb3
only has ~10-16ms resolution. Use higher rez timer to get 1ms rez.