### PR TITLE
core: cache block template where possible

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -104,7 +104,8 @@ static const uint64_t testnet_hard_fork_version_1_till = 624633;
 //------------------------------------------------------------------
 Blockchain::Blockchain(tx_memory_pool& tx_pool) :
   m_db(), m_tx_pool(tx_pool), m_hardfork(NULL), m_timestamps_and_difficulties_height(0), m_current_block_cumul_sz_limit(0), m_is_in_checkpoint_zone(false),
-  m_is_blockchain_storing(false), m_enforce_dns_checkpoints(false), m_max_prepare_blocks_threads(4), m_db_blocks_per_sync(1), m_db_sync_mode(db_async), m_fast_sync(true), m_show_time_stats(false), m_sync_counter(0)
+  m_is_blockchain_storing(false), m_enforce_dns_checkpoints(false), m_max_prepare_blocks_threads(4), m_db_blocks_per_sync(1), m_db_sync_mode(db_async), m_fast_sync(true), m_show_time_stats(false), m_sync_counter(0),
+  m_btc_valid(false)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
 }
@@ -499,6 +500,7 @@ block Blockchain::pop_block_from_blockchain()
     }
   }
   m_tx_pool.on_blockchain_dec(m_db->height()-1, get_tail_id());
+  invalidate_block_template_cache();
 
   return popped_block;
 }
@@ -508,6 +510,7 @@ bool Blockchain::reset_and_set_genesis_block(const block& b)
   LOG_PRINT_L3("Blockchain::" << __func__);
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
   m_alternative_chains.clear();
+  invalidate_block_template_cache();
   m_db->reset();
   m_hardfork->init();
 
@@ -1038,14 +1041,30 @@ uint64_t Blockchain::get_current_cumulative_blocksize_limit() const
 // in a lot of places.  That flag is not referenced in any of the code
 // nor any of the makefiles, howeve.  Need to look into whether or not it's
 // necessary at all.
-bool Blockchain::create_block_template(block& b, const account_public_address& miner_address, difficulty_type& diffic, uint64_t& height, const blobdata& ex_nonce)
+bool Blockchain::create_block_template(block& b, const cryptonote::account_public_address& miner_address, difficulty_type& diffic, uint64_t& height, const blobdata& ex_nonce)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
   size_t median_size;
   uint64_t already_generated_coins;
+  uint64_t pool_cookie;
 
   CRITICAL_REGION_BEGIN(m_blockchain_lock);
   height = m_db->height();
+  if (m_btc_valid) {
+    // The pool cookie is atomic. The lack of locking is OK, as if it changes
+    // just as we compare it, we'll just use a slightly old template, but
+    // this would be the case anyway if we'd lock, and the change happened
+    // just after the block template was created
+    if (!memcmp(&miner_address, &m_btc_address, sizeof(cryptonote::account_public_address)) && m_btc_nonce == ex_nonce && m_btc_pool_cookie == m_tx_pool.cookie()) {
+      LOG_PRINT_L2("Using cached template");
+      m_btc.timestamp = time(NULL); // update timestamp unconditionally
+      b = m_btc;
+      diffic = m_btc_difficulty;
+      return true;
+    }
+    LOG_PRINT_L2("Not using cached template: address " << (!memcmp(&miner_address, &m_btc_address, sizeof(cryptonote::account_public_address))) << ", nonce " << (m_btc_nonce == ex_nonce) << ", cookie " << (m_btc_pool_cookie == m_tx_pool.cookie()));
+    invalidate_block_template_cache();
+  }
 
   b.major_version = m_hardfork->get_current_version();
   b.minor_version = m_hardfork->get_ideal_version();
@@ -1066,6 +1085,7 @@ bool Blockchain::create_block_template(block& b, const account_public_address& m
   {
     return false;
   }
+  pool_cookie = m_tx_pool.cookie();
 #if defined(DEBUG_CREATE_BLOCK_TEMPLATE)
   size_t real_txs_size = 0;
   uint64_t real_fee = 0;
@@ -1168,6 +1188,8 @@ bool Blockchain::create_block_template(block& b, const account_public_address& m
     LOG_PRINT_L1("Creating block template: miner tx size " << coinbase_blob_size <<
         ", cumulative size " << cumulative_size << " is now good");
 #endif
+
+    cache_block_template(b, miner_address, ex_nonce, diffic, pool_cookie);
     return true;
   }
   LOG_ERROR("Failed to create_block_template with " << 10 << " tries");
@@ -2769,6 +2791,7 @@ leave:
 
   // appears to be a NOP *and* is called elsewhere.  wat?
   m_tx_pool.on_blockchain_inc(new_height, id);
+  invalidate_block_template_cache();
 
   return true;
 }
@@ -3376,4 +3399,21 @@ bool Blockchain::for_all_transactions(std::function<bool(const crypto::hash&, co
 bool Blockchain::for_all_outputs(std::function<bool(uint64_t amount, const crypto::hash &tx_hash, size_t tx_idx)> f) const
 {
   return m_db->for_all_outputs(f);;
+}
+
+void Blockchain::invalidate_block_template_cache()
+{
+  LOG_PRINT_L2("Invalidating block template cache");
+  m_btc_valid = false;
+}
+
+void Blockchain::cache_block_template(const block &b, const cryptonote::account_public_address &address, const blobdata &nonce, const difficulty_type &diff, uint64_t pool_cookie)
+{
+  LOG_PRINT_L2("Setting block template cache");
+  m_btc = b;
+  m_btc_address = address;
+  m_btc_nonce = nonce;
+  m_btc_difficulty = diff;
+  m_btc_pool_cookie = pool_cookie;
+  m_btc_valid = true;
 }

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -829,6 +829,14 @@ namespace cryptonote
 
     bool m_testnet;
 
+    // block template cache
+    block m_btc;
+    account_public_address m_btc_address;
+    blobdata m_btc_nonce;
+    difficulty_type m_btc_difficulty;
+    uint64_t m_btc_pool_cookie;
+    bool m_btc_valid;
+
     /**
      * @brief collects the keys for all outputs being "spent" as an input
      *
@@ -1159,5 +1167,17 @@ namespace cryptonote
      * a useful state.
      */
     void load_compiled_in_block_hashes();
+
+    /**
+     * @brief invalidates any cached block template
+     */
+    void invalidate_block_template_cache();
+
+    /**
+     * @brief stores a new cached block template
+     *
+     * At some point, may be used to push an update to miners
+     */
+    void cache_block_template(const block &b, const cryptonote::account_public_address &address, const blobdata &nonce, const difficulty_type &diff, uint64_t pool_cookie);
   };
 }  // namespace cryptonote

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -76,12 +76,12 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
 #if BLOCKCHAIN_DB == DB_LMDB
   //---------------------------------------------------------------------------------
-  tx_memory_pool::tx_memory_pool(Blockchain& bchs): m_blockchain(bchs)
+  tx_memory_pool::tx_memory_pool(Blockchain& bchs): m_blockchain(bchs), m_cookie(0)
   {
 
   }
 #else
-  tx_memory_pool::tx_memory_pool(blockchain_storage& bchs): m_blockchain(bchs)
+  tx_memory_pool::tx_memory_pool(blockchain_storage& bchs): m_blockchain(bchs), m_cookie(0)
   {
 
   }
@@ -240,6 +240,8 @@ namespace cryptonote
 
     m_txs_by_fee.emplace((double)blob_size / fee, id);
 
+    ++m_cookie;
+
     return true;
   }
   //---------------------------------------------------------------------------------
@@ -281,6 +283,7 @@ namespace cryptonote
       }
 
     }
+    ++m_cookie;
     return true;
   }
   //---------------------------------------------------------------------------------
@@ -303,6 +306,7 @@ namespace cryptonote
     remove_transaction_keyimages(it->second.tx);
     m_transactions.erase(it);
     m_txs_by_fee.erase(sorted_it);
+    ++m_cookie;
     return true;
   }
   //---------------------------------------------------------------------------------
@@ -324,6 +328,7 @@ namespace cryptonote
   bool tx_memory_pool::remove_stuck_transactions()
   {
     CRITICAL_REGION_LOCAL(m_transactions_lock);
+    bool changed = false;
     for(auto it = m_transactions.begin(); it!= m_transactions.end();)
     {
       uint64_t tx_age = time(nullptr) - it->second.receive_time;
@@ -345,9 +350,12 @@ namespace cryptonote
         m_timed_out_transactions.insert(it->first);
         auto pit = it++;
         m_transactions.erase(pit);
+        changed = true;
       }else
         ++it;
     }
+    if (changed)
+      ++m_cookie;
     return true;
   }
   //---------------------------------------------------------------------------------
@@ -385,6 +393,7 @@ namespace cryptonote
       if (i != m_transactions.end())
         i->second.last_relayed_time = now;
     }
+    ++m_cookie;
   }
   //---------------------------------------------------------------------------------
   size_t tx_memory_pool::get_transactions_count() const
@@ -671,6 +680,8 @@ namespace cryptonote
       }
       it++;
     }
+    if (n_removed > 0)
+      ++m_cookie;
     return n_removed;
   }
   //---------------------------------------------------------------------------------
@@ -702,6 +713,8 @@ namespace cryptonote
     {
       m_txs_by_fee.emplace((double)tx.second.blob_size / tx.second.fee, tx.first);
     }
+
+    m_cookie = 0;
 
     // Ignore deserialization error
     return true;

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -308,6 +308,13 @@ namespace cryptonote
      */
     size_t validate(uint8_t version);
 
+     /**
+      * @brief return the cookie
+      *
+      * @return the cookie
+      */
+     uint64_t cookie() const { return m_cookie; }
+
 
 #define CURRENT_MEMPOOL_ARCHIVE_VER    11
 #define CURRENT_MEMPOOL_TX_DETAILS_ARCHIVE_VER    11
@@ -475,6 +482,8 @@ namespace cryptonote
 
     //TODO: look into doing this better
     sorted_tx_container m_txs_by_fee;  //!< container for transactions organized by fee per size
+
+    std::atomic<uint64_t> m_cookie; //!< incremented at each change
 
     /**
      * @brief get an iterator to a transaction in the sorted container


### PR DESCRIPTION
This avoids constant rechecking of the same things each time
a miner asks for the block template. The tx pool maintains
a cookie to allow users to detect when the pool state changed,
which means the block template needs rebuilding.