### PR TITLE
Fix unconfirmed balance, accurately report fees

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2202,24 +2202,36 @@ bool simple_wallet::transfer_main(bool new_algorithm, const std::vector<std::str
     if (m_wallet->always_confirm_transfers() || ptx_vector.size() > 1)
     {
         uint64_t total_fee = 0;
+        uint64_t dust_not_in_fee = 0;
+        uint64_t dust_in_fee = 0;
         for (size_t n = 0; n < ptx_vector.size(); ++n)
         {
           total_fee += ptx_vector[n].fee;
+
+          if (ptx_vector[n].dust_added_to_fee)
+            dust_in_fee += ptx_vector[n].dust;
+          else
+            dust_not_in_fee += ptx_vector[n].dust;
         }
 
-        std::string prompt_str;
+        std::stringstream prompt;
         if (ptx_vector.size() > 1)
         {
-          prompt_str = (boost::format(tr("Your transaction needs to be split into %llu transactions.  "
-            "This will result in a transaction fee being applied to each transaction, for a total fee of %s.  Is this okay?  (Y/Yes/N/No)")) %
-            ((unsigned long long)ptx_vector.size()) % print_money(total_fee)).str();
+          prompt << boost::format(tr("Your transaction needs to be split into %llu transactions.  "
+            "This will result in a transaction fee being applied to each transaction, for a total fee of %s")) %
+            ((unsigned long long)ptx_vector.size()) % print_money(total_fee);
         }
         else
         {
-          prompt_str = (boost::format(tr("The transaction fee is %s.  Is this okay?  (Y/Yes/N/No)")) %
-            print_money(total_fee)).str();
+          prompt << boost::format(tr("The transaction fee is %s")) %
+            print_money(total_fee);
         }
-        std::string accepted = command_line::input_line(prompt_str);
+        if (dust_in_fee != 0) prompt << boost::format(tr(", of which %s is dust from change")) % print_money(dust_in_fee);
+        if (dust_not_in_fee != 0)  prompt << tr(".") << ENDL << boost::format(tr("A total of %s from dust change will be sent to dust address")) 
+                                                   % print_money(dust_not_in_fee);
+        prompt << tr(".") << ENDL << tr("Is this okay?  (Y/Yes/N/No)");
+        
+        std::string accepted = command_line::input_line(prompt.str());
         if (std::cin.eof())
           return true;
         if (accepted != "Y" && accepted != "y" && accepted != "Yes" && accepted != "yes")

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1966,8 +1966,9 @@ void wallet2::commit_tx(pending_tx& ptx)
   BOOST_FOREACH(transfer_container::iterator it, ptx.selected_transfers)
     it->m_spent = true;
 
+  //fee includes dust if dust policy specified it.
   LOG_PRINT_L0("Transaction successfully sent. <" << txid << ">" << ENDL
-            << "Commission: " << print_money(ptx.fee) << " (dust sent to dust addr: " << print_money((ptx.dust_added_to_fee ? 0 : ptx.dust)) << ")" << ENDL  //AC: fee includes dust; dust lists dust sent elsewhere
+            << "Commission: " << print_money(ptx.fee) << " (dust sent to dust addr: " << print_money((ptx.dust_added_to_fee ? 0 : ptx.dust)) << ")" << ENDL
             << "Balance: " << print_money(balance()) << ENDL
             << "Unlocked: " << print_money(unlocked_balance()) << ENDL
             << "Please, wait for confirmation for your balance to be unlocked.");
@@ -2230,7 +2231,7 @@ void wallet2::transfer_selected(const std::vector<cryptonote::tx_destination_ent
   bool dust_sent_elsewhere = (dust_policy.addr_for_dust.m_view_public_key != change_dts.addr.m_view_public_key
                                 || dust_policy.addr_for_dust.m_spend_public_key != change_dts.addr.m_spend_public_key);
   
-  if (dust_policy.add_to_fee || dust_sent_elsewhere) change_dts.amount -= dust;     //AC
+  if (dust_policy.add_to_fee || dust_sent_elsewhere) change_dts.amount -= dust;
 
   ptx.key_images = key_images;
   ptx.fee = (dust_policy.add_to_fee ? fee+dust : fee);
@@ -2400,7 +2401,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
         detail::digit_split_strategy, tx_dust_policy(::config::DEFAULT_DUST_THRESHOLD), test_tx, test_ptx);
       auto txBlob = t_serializable_object_to_blob(test_ptx.tx);
       needed_fee = calculate_fee(txBlob);
-      available_for_fee = test_ptx.fee + test_ptx.change_dts.amount + (!test_ptx.dust_added_to_fee ? test_ptx.dust : 0);   //AC
+      available_for_fee = test_ptx.fee + test_ptx.change_dts.amount + (!test_ptx.dust_added_to_fee ? test_ptx.dust : 0);
       LOG_PRINT_L2("Made a " << txBlob.size() << " kB tx, with " << print_money(available_for_fee) << " available for fee (" <<
         print_money(needed_fee) << " needed)");
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -143,7 +143,7 @@ namespace tools
     {
       cryptonote::transaction tx;
       uint64_t dust, fee;
-      bool dust_added_to_fee;                           //AC
+      bool dust_added_to_fee;
       cryptonote::tx_destination_entry change_dts;
       std::list<transfer_container::iterator> selected_transfers;
       std::string key_images;
@@ -721,7 +721,7 @@ namespace tools
     ptx.key_images = key_images;
     ptx.fee = (dust_policy.add_to_fee ? fee+dust : fee);
     ptx.dust = ((dust_policy.add_to_fee || dust_sent_elsewhere) ? dust : 0);
-    ptx.dust_added_to_fee = dust_policy.add_to_fee;         //AC
+    ptx.dust_added_to_fee = dust_policy.add_to_fee;
     ptx.tx = tx;
     ptx.change_dts = change_dts;
     ptx.selected_transfers = selected_transfers;


### PR DESCRIPTION
Wallet balance can be misreported when there are unconfirmed transactions with dust amounts generated from change.

If dust is meant to be added to fee or sent elsewhere to a specific dust address, the change amount was not updated to reflect this.

Suggested fix:

I have mainly modified transfer, transfer_selected.  After tx details have been worked out, do the following:
   -ptx.fee has dust explicitly added to it if specified by the dust policy.
   -change_dts.amount has dust subtracted from it if dust is added to fee or sent elsewhere 
   -dust is zero if it is not added to fee and not sent elsewhere (i.e. it's still in the change)

In addition I've made the confirm prompt in simple_wallet::transfer a little bit more verbose so the user knows more about what's going on in regards to dust amounts.

I have not looked at sweep_unmixable at all.