### PR TITLE
random: call abort(3) instead of assert in must_succeed macro

### DIFF
--- a/src/crypto/random.c
+++ b/src/crypto/random.c
@@ -45,7 +45,7 @@ static void generate_system_random_bytes(size_t n, void *result);
 
 static void generate_system_random_bytes(size_t n, void *result) {
   HCRYPTPROV prov;
-#define must_succeed(x) do if (!(x)) assert(0); while (0)
+#define must_succeed(x) do if (!(x)) abort(); while (0)
   must_succeed(CryptAcquireContext(&prov, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT | CRYPT_SILENT));
   must_succeed(CryptGenRandom(prov, (DWORD)n, result));
   must_succeed(CryptReleaseContext(prov, 0));


### PR DESCRIPTION
Avoids silent use of bad RNG in release builds, in case those
calls might actually fail.

Reported by smooth.