### PR TITLE
wallet: add get_transfers rpc call

### DIFF
--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -79,6 +79,7 @@ namespace tools
         MAP_JON_RPC_WE("rescan_blockchain",  on_rescan_blockchain,  wallet_rpc::COMMAND_RPC_RESCAN_BLOCKCHAIN)
         MAP_JON_RPC_WE("set_tx_notes",       on_set_tx_notes,       wallet_rpc::COMMAND_RPC_SET_TX_NOTES)
         MAP_JON_RPC_WE("get_tx_notes",       on_get_tx_notes,       wallet_rpc::COMMAND_RPC_GET_TX_NOTES)
+        MAP_JON_RPC_WE("get_transfers",      on_get_transfers,      wallet_rpc::COMMAND_RPC_GET_TRANSFERS)
       END_JSON_RPC_MAP()
     END_URI_MAP2()
 
@@ -101,6 +102,7 @@ namespace tools
       bool on_rescan_blockchain(const wallet_rpc::COMMAND_RPC_RESCAN_BLOCKCHAIN::request& req, wallet_rpc::COMMAND_RPC_RESCAN_BLOCKCHAIN::response& res, epee::json_rpc::error& er);
       bool on_set_tx_notes(const wallet_rpc::COMMAND_RPC_SET_TX_NOTES::request& req, wallet_rpc::COMMAND_RPC_SET_TX_NOTES::response& res, epee::json_rpc::error& er);
       bool on_get_tx_notes(const wallet_rpc::COMMAND_RPC_GET_TX_NOTES::request& req, wallet_rpc::COMMAND_RPC_GET_TX_NOTES::response& res, epee::json_rpc::error& er);
+      bool on_get_transfers(const wallet_rpc::COMMAND_RPC_GET_TRANSFERS::request& req, wallet_rpc::COMMAND_RPC_GET_TRANSFERS::response& res, epee::json_rpc::error& er);
 
       bool handle_command_line(const boost::program_options::variables_map& vm);
 

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -488,6 +488,66 @@ namespace wallet_rpc
     };
   };
 
+  struct COMMAND_RPC_GET_TRANSFERS
+  {
+    struct request
+    {
+      bool in;
+      bool out;
+      bool pending;
+      bool failed;
+      uint64_t min_height;
+      uint64_t max_height;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(in);
+        KV_SERIALIZE(out);
+        KV_SERIALIZE(pending);
+        KV_SERIALIZE(failed);
+        KV_SERIALIZE(min_height);
+        KV_SERIALIZE(max_height);
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct entry
+    {
+      std::string txid;
+      std::string payment_id;
+      uint64_t height;
+      uint64_t timestamp;
+      uint64_t amount;
+      uint64_t fee;
+      std::string note;
+      std::list<transfer_destination> destinations;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(txid);
+        KV_SERIALIZE(payment_id);
+        KV_SERIALIZE(height);
+        KV_SERIALIZE(timestamp);
+        KV_SERIALIZE(amount);
+        KV_SERIALIZE(fee);
+        KV_SERIALIZE(note);
+        KV_SERIALIZE(destinations);
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      std::list<entry> in;
+      std::list<entry> out;
+      std::list<entry> pending;
+      std::list<entry> failed;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(in);
+        KV_SERIALIZE(out);
+        KV_SERIALIZE(pending);
+        KV_SERIALIZE(failed);
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
 }
 }
 


### PR DESCRIPTION
Allows getting in, out, pending, and failed transfers, similarly
to the show_transfers command.