### PR TITLE
wallet: add a filter_by_height field to get_transfers

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -842,10 +842,17 @@ namespace tools
       return false;
     }
 
+    uint64_t min_height = 0, max_height = (uint64_t)-1;
+    if (req.filter_by_height)
+    {
+      min_height = req.min_height;
+      max_height = req.max_height;
+    }
+
     if (req.in)
     {
       std::list<std::pair<crypto::hash, tools::wallet2::payment_details>> payments;
-      m_wallet.get_payments(payments, req.min_height, req.max_height);
+      m_wallet.get_payments(payments, min_height, max_height);
       for (std::list<std::pair<crypto::hash, tools::wallet2::payment_details>>::const_iterator i = payments.begin(); i != payments.end(); ++i) {
         res.in.push_back(wallet_rpc::COMMAND_RPC_GET_TRANSFERS::entry());
         wallet_rpc::COMMAND_RPC_GET_TRANSFERS::entry &entry = res.in.back();
@@ -866,7 +873,7 @@ namespace tools
     if (req.out)
     {
       std::list<std::pair<crypto::hash, tools::wallet2::confirmed_transfer_details>> payments;
-      m_wallet.get_payments_out(payments, req.min_height, req.max_height);
+      m_wallet.get_payments_out(payments, min_height, max_height);
       for (std::list<std::pair<crypto::hash, tools::wallet2::confirmed_transfer_details>>::const_iterator i = payments.begin(); i != payments.end(); ++i) {
         res.in.push_back(wallet_rpc::COMMAND_RPC_GET_TRANSFERS::entry());
         wallet_rpc::COMMAND_RPC_GET_TRANSFERS::entry &entry = res.in.back();

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -496,6 +496,8 @@ namespace wallet_rpc
       bool out;
       bool pending;
       bool failed;
+
+      bool filter_by_height;
       uint64_t min_height;
       uint64_t max_height;
 
@@ -504,6 +506,7 @@ namespace wallet_rpc
         KV_SERIALIZE(out);
         KV_SERIALIZE(pending);
         KV_SERIALIZE(failed);
+        KV_SERIALIZE(filter_by_height);
         KV_SERIALIZE(min_height);
         KV_SERIALIZE(max_height);
       END_KV_SERIALIZE_MAP()


### PR DESCRIPTION
It allows a simple get_transfers (with default 0 min_height and
max_height) to return all transactions, instead of the unexpected
set of txes in block 0, which is probably none at all.