### PR TITLE
add a --max-concurency flag

### DIFF
--- a/src/blockchain_db/berkeleydb/db_bdb.cpp
+++ b/src/blockchain_db/berkeleydb/db_bdb.cpp
@@ -135,7 +135,7 @@ const unsigned int DB_BUFFER_LENGTH = 32 * MB;
 const unsigned int DB_DEF_CACHESIZE = 256 * MB;
 
 #if defined(BDB_BULK_CAN_THREAD)
-const unsigned int DB_BUFFER_COUNT = boost::thread::hardware_concurrency();
+const unsigned int DB_BUFFER_COUNT = tools::get_max_concurrency();
 #else
 const unsigned int DB_BUFFER_COUNT = 1;
 #endif

--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -422,4 +422,27 @@ std::string get_nix_version_display_string()
     umask(mode);
 #endif
   }
+
+  namespace
+  {
+    boost::mutex max_concurrency_lock;
+    unsigned max_concurrency = boost::thread::hardware_concurrency();
+  }
+
+  void set_max_concurrency(unsigned n)
+  {
+    if (n < 1)
+      n = boost::thread::hardware_concurrency();
+    unsigned hwc = boost::thread::hardware_concurrency();
+    if (n > hwc)
+      n = hwc;
+    boost::lock_guard<boost::mutex> lock(max_concurrency_lock);
+    max_concurrency = n;
+  }
+
+  unsigned get_max_concurrency()
+  {
+    boost::lock_guard<boost::mutex> lock(max_concurrency_lock);
+    return max_concurrency;
+  }
 }

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -160,4 +160,7 @@ namespace tools
   };
 
   void set_strict_default_file_permissions(bool strict);
+
+  void set_max_concurrency(unsigned n);
+  unsigned get_max_concurrency();
 }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2124,7 +2124,7 @@ bool Blockchain::check_tx_inputs(const transaction& tx, tx_verification_context 
   std::vector < uint64_t > results;
   results.resize(tx.vin.size(), 0);
 
-  int threads = boost::thread::hardware_concurrency();
+  int threads = tools::get_max_concurrency();
 
   boost::asio::io_service ioservice;
   boost::thread_group threadpool;
@@ -3001,7 +3001,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::list<block_complete_e
     return true;
 
   bool blocks_exist = false;
-  uint64_t threads = boost::thread::hardware_concurrency();
+  uint64_t threads = tools::get_max_concurrency();
 
   if (blocks_entry.size() > 1 && threads > 1 && m_max_prepare_blocks_threads > 1)
   {
@@ -3200,7 +3200,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::list<block_complete_e
   // [output] stores all transactions for each tx_out_index::hash found
   std::vector<std::unordered_map<crypto::hash, cryptonote::transaction>> transactions(amounts.size());
 
-  threads = boost::thread::hardware_concurrency();
+  threads = tools::get_max_concurrency();
   if (!m_db->can_thread_bulk_indices())
     threads = 1;
 

--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -59,6 +59,11 @@ namespace daemon_args
     "os-version"
   , "OS for which this executable was compiled"
   };
+  const command_line::arg_descriptor<unsigned> arg_max_concurrency = {
+    "max-concurrency"
+  , "Max number of threads to use for a parallel job"
+  , 0
+  };
 }  // namespace daemon_args
 
 #endif // DAEMON_COMMAND_LINE_ARGS_H

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -81,6 +81,7 @@ int main(int argc, char const * argv[])
       bf::path default_log = default_data_dir / std::string(CRYPTONOTE_NAME ".log");
       command_line::add_arg(core_settings, daemon_args::arg_log_file, default_log.string());
       command_line::add_arg(core_settings, daemon_args::arg_log_level);
+      command_line::add_arg(core_settings, daemon_args::arg_max_concurrency);
 
       daemonizer::init_options(hidden_options, visible_options);
       daemonize::t_executor::init_options(core_settings);
@@ -259,6 +260,9 @@ int main(int argc, char const * argv[])
         , log_file_path.parent_path().string().c_str()
         );
     }
+
+    if (command_line::has_arg(vm, daemon_args::arg_max_concurrency))
+      tools::set_max_concurrency(command_line::get_arg(vm, daemon_args::arg_max_concurrency));
 
     _note_c("dbg/main", "Moving from main() into the daemonize now.");
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -213,7 +213,7 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, uint64_
 
     tx_pub_key = pub_key_field.pub_key;
     bool r = true;
-    int threads = boost::thread::hardware_concurrency();
+    int threads = tools::get_max_concurrency();
     if (miner_tx && m_refresh_type == RefreshNoCoinbase)
     {
       // assume coinbase isn't for us
@@ -603,7 +603,7 @@ void wallet2::process_blocks(uint64_t start_height, const std::list<cryptonote::
   size_t current_index = start_height;
   blocks_added = 0;
 
-  int threads = boost::thread::hardware_concurrency();
+  int threads = tools::get_max_concurrency();
   if (threads > 1)
   {
     std::vector<crypto::hash> round_block_hashes(threads);


### PR DESCRIPTION
It sets the max number of threads to use for a parallel job.
This is different that the number of total threads, since monero
binaries typically start a lot of them.