### PR TITLE
crypto: make clear generate_random_bytes is not thread safe

### DIFF
--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -83,7 +83,7 @@ namespace crypto {
   /* generate a random 32-byte (256-bit) integer and copy it to res */
   static inline void random_scalar(ec_scalar &res) {
     unsigned char tmp[64];
-    generate_random_bytes(64, tmp);
+    generate_random_bytes_not_thread_safe(64, tmp);
     sc_reduce(tmp);
     memcpy(&res, tmp, 32);
   }

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -117,13 +117,20 @@ namespace crypto {
       const public_key *const *, std::size_t, const signature *);
   };
 
+  /* Generate N random bytes
+   */
+  inline void rand(size_t N, uint8_t *bytes) {
+    boost::lock_guard<boost::mutex> lock(random_lock);
+    generate_random_bytes_not_thread_safe(N, bytes);
+  }
+
   /* Generate a value filled with random bytes.
    */
   template<typename T>
   typename std::enable_if<std::is_pod<T>::value, T>::type rand() {
     typename std::remove_cv<T>::type res;
     boost::lock_guard<boost::mutex> lock(random_lock);
-    generate_random_bytes(sizeof(T), &res);
+    generate_random_bytes_not_thread_safe(sizeof(T), &res);
     return res;
   }
 

--- a/src/crypto/random.c
+++ b/src/crypto/random.c
@@ -113,7 +113,7 @@ INITIALIZER(init_random) {
 #endif
 }
 
-void generate_random_bytes(size_t n, void *result) {
+void generate_random_bytes_not_thread_safe(size_t n, void *result) {
 #if !defined(NDEBUG)
   assert(curstate == 1);
   curstate = 2;

--- a/src/crypto/random.h
+++ b/src/crypto/random.h
@@ -32,4 +32,4 @@
 
 #include <stddef.h>
 
-void generate_random_bytes(size_t n, void *result);
+void generate_random_bytes_not_thread_safe(size_t n, void *result);


### PR DESCRIPTION
And add a thread safe version to encourage proper use