### PR TITLE
Proposed code fixes for compilation using gcc 6.1 on Arch LInux

### DIFF
--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -272,7 +272,7 @@ DISABLE_VS_WARNINGS(4200)
 POP_WARNINGS
 
   static inline size_t rs_comm_size(size_t pubs_count) {
-    return sizeof(rs_comm) + pubs_count * sizeof(rs_comm().ab[0]);
+    return sizeof(rs_comm) + pubs_count * 2 * sizeof(ec_point);
   }
 
   void crypto_ops::generate_ring_signature(const hash &prefix_hash, const key_image &image,

--- a/tests/unit_tests/hardfork.cpp
+++ b/tests/unit_tests/hardfork.cpp
@@ -129,7 +129,9 @@ public:
     return starting_height[version];
   }
   virtual void set_hard_fork_version(uint64_t height, uint8_t version) {
-    if (versions.size() <= height) versions.resize(height+1); versions[height] = version;
+    if (versions.size() <= height) 
+      versions.resize(height+1); 
+    versions[height] = version;
   }
   virtual uint8_t get_hard_fork_version(uint64_t height) const {
     return versions[height];


### PR DESCRIPTION
Compilation of Bitmonero on Arch with gcc 6.1 results in sever errors.

https://github.com/monero-project/bitmonero/issues/834

The two commits are proposed solutions to the following the two errors:

1.  **error: value-initialization of incomplete type**
```
/home/mwo/bitmonero/src/crypto/crypto.cpp:275:58: error: value-initialization of incomplete type ‘crypto::rs_comm::<anonymous struct> []’
     return sizeof(rs_comm) + pubs_count * sizeof(rs_comm().ab[0]);
```
2. **error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]**

```
. /home/mwo/bitmonero/tests/unit_tests/hardfork.cpp: In member function ‘virtual void TestDB::set_hard_fork_version(uint64_t, uint8_t)’:
/home/mwo/bitmonero/tests/unit_tests/hardfork.cpp:132:5: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
```
