### PR TITLE
contrib: epee: add missing noexcept spec to class decl

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -95,7 +95,7 @@ namespace net_utils
 			i_connection_filter * &pfilter
 			,t_connection_type connection_type);
 
-    virtual ~connection();
+    virtual ~connection() noexcept(false);
     /// Get the socket associated with the connection.
     boost::asio::ip::tcp::socket& socket();
 


### PR DESCRIPTION
The noexcept specs were added to make GCC 6.1.1 happy (#846), but this
one was missing (because GCC did not complain about it on Linux, but
does complain on OSX).

This is an attempt to fix #871 