### PR TITLE
wallet: add a fee multiplier

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -485,6 +485,68 @@ bool simple_wallet::set_default_mixin(const std::vector<std::string> &args/* = s
   }
 }
 
+bool simple_wallet::set_default_fee_multiplier(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
+{
+  bool success = false;
+  int fee_multiplier = 0;
+  if (m_wallet->watch_only())
+  {
+    fail_msg_writer() << tr("wallet is watch-only and cannot transfer");
+    return true;
+  }
+  try
+  {
+    if (strchr(args[1].c_str(), '-'))
+    {
+      fail_msg_writer() << tr("fee multiplier must be 0, 1, 2, or 3 ");
+      return true;
+    }
+    if (args[1] == "0")
+    {
+      fee_multiplier = 0;
+    }
+    else
+    {
+      fee_multiplier = boost::lexical_cast<int>(args[1]);
+      if (fee_multiplier != 1 && fee_multiplier != 2 && fee_multiplier != 3)
+      {
+        fail_msg_writer() << tr("fee multiplier must be 0, 1, 2, or 3");
+        return true;
+      }
+    }
+
+    tools::password_container pwd_container;
+    success = pwd_container.read_password();
+    if (!success)
+    {
+      fail_msg_writer() << tr("failed to read wallet password");
+      return true;
+    }
+
+    /* verify password before using so user doesn't accidentally set a new password for rewritten wallet */
+    success = m_wallet->verify_password(pwd_container.password());
+    if (!success)
+    {
+      fail_msg_writer() << tr("invalid password");
+      return true;
+    }
+
+    m_wallet->set_default_fee_multiplier(fee_multiplier);
+    m_wallet->rewrite(m_wallet_file, pwd_container.password());
+    return true;
+  }
+  catch(const boost::bad_lexical_cast &)
+  {
+    fail_msg_writer() << tr("fee multiplier must be 0, 1, 2 or 3");
+    return true;
+  }
+  catch(...)
+  {
+    fail_msg_writer() << tr("could not change default fee multiplier");
+    return true;
+  }
+}
+
 bool simple_wallet::set_auto_refresh(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
   bool success = false;
@@ -587,7 +649,7 @@ simple_wallet::simple_wallet()
   m_cmd_binder.set_handler("viewkey", boost::bind(&simple_wallet::viewkey, this, _1), tr("Display private view key"));
   m_cmd_binder.set_handler("spendkey", boost::bind(&simple_wallet::spendkey, this, _1), tr("Display private spend key"));
   m_cmd_binder.set_handler("seed", boost::bind(&simple_wallet::seed, this, _1), tr("Display Electrum-style mnemonic seed"));
-  m_cmd_binder.set_handler("set", boost::bind(&simple_wallet::set_variable, this, _1), tr("Available options: seed language - set wallet seed language; always-confirm-transfers <1|0> - whether to confirm unsplit txes; store-tx-info <1|0> - whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference; default-mixin <n> - set default mixin (default default is 4); auto-refresh <1|0> - whether to automatically sync new blocks from the daemon; refresh-type <full|optimize-coinbase|no-coinbase|default> - set wallet refresh behaviour"));
+  m_cmd_binder.set_handler("set", boost::bind(&simple_wallet::set_variable, this, _1), tr("Available options: seed language - set wallet seed language; always-confirm-transfers <1|0> - whether to confirm unsplit txes; store-tx-info <1|0> - whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference; default-mixin <n> - set default mixin (default default is 4); auto-refresh <1|0> - whether to automatically sync new blocks from the daemon; refresh-type <full|optimize-coinbase|no-coinbase|default> - set wallet refresh behaviour; fee-multiplier [1|2|3] - normal/elevated/priority fee"));
   m_cmd_binder.set_handler("rescan_spent", boost::bind(&simple_wallet::rescan_spent, this, _1), tr("Rescan blockchain for spent outputs"));
   m_cmd_binder.set_handler("get_tx_key", boost::bind(&simple_wallet::get_tx_key, this, _1), tr("Get transaction key (r) for a given <txid>"));
   m_cmd_binder.set_handler("check_tx_key", boost::bind(&simple_wallet::check_tx_key, this, _1), tr("Check amount going to <address> in <txid>"));
@@ -609,6 +671,7 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
     success_msg_writer() << "default-mixin = " << m_wallet->default_mixin();
     success_msg_writer() << "auto-refresh = " << m_wallet->auto_refresh();
     success_msg_writer() << "refresh-type = " << get_refresh_type_name(m_wallet->get_refresh_type());
+    success_msg_writer() << "fee-multiplier = " << m_wallet->get_default_fee_multiplier();
     return true;
   }
   else
@@ -701,6 +764,21 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
         std::vector<std::string> local_args = args;
         local_args.erase(local_args.begin(), local_args.begin()+2);
         set_refresh_type(local_args);
+        return true;
+      }
+    }
+    else if (args[0] == "fee-multiplier")
+    {
+      if (args.size() <= 1)
+      {
+        fail_msg_writer() << tr("set fee-multiplier: needs an argument: 0, 1, 2, or 3");
+        return true;
+      }
+      else
+      {
+        std::vector<std::string> local_args = args;
+        local_args.erase(local_args.begin(), local_args.begin()+2);
+        set_default_fee_multiplier(local_args);
         return true;
       }
     }

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -142,6 +142,7 @@ namespace cryptonote
     bool set_tx_note(const std::vector<std::string> &args);
     bool get_tx_note(const std::vector<std::string> &args);
     bool status(const std::vector<std::string> &args);
+    bool set_default_fee_multiplier(const std::vector<std::string> &args);
 
     uint64_t get_daemon_blockchain_height(std::string& err);
     bool try_connect_to_daemon();

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -88,10 +88,10 @@ namespace tools
     };
 
   private:
-    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers (false), m_store_tx_info(true), m_default_mixin(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0) {}
+    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers (false), m_store_tx_info(true), m_default_mixin(0), m_default_fee_multiplier(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0) {}
 
   public:
-    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_restricted(restricted), is_old_file_format(false), m_store_tx_info(true), m_default_mixin(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0) {}
+    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_restricted(restricted), is_old_file_format(false), m_store_tx_info(true), m_default_mixin(0), m_default_fee_multiplier(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0) {}
     struct transfer_details
     {
       uint64_t m_block_height;
@@ -291,9 +291,9 @@ namespace tools
 
     void commit_tx(pending_tx& ptx_vector);
     void commit_tx(std::vector<pending_tx>& ptx_vector);
-    std::vector<pending_tx> create_transactions(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, const uint64_t fee, const std::vector<uint8_t> extra, bool trusted_daemon);
-    std::vector<wallet2::pending_tx> create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, const uint64_t fee_UNUSED, const std::vector<uint8_t> extra, bool trusted_daemon);
-    std::vector<wallet2::pending_tx> create_transactions_all(const cryptonote::account_public_address &address, const size_t fake_outs_count, const uint64_t unlock_time, const uint64_t fee_UNUSED, const std::vector<uint8_t> extra, bool trusted_daemon);
+    std::vector<pending_tx> create_transactions(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, uint64_t fee_multiplier, const std::vector<uint8_t> extra, bool trusted_daemon);
+    std::vector<wallet2::pending_tx> create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, uint64_t fee_multiplier, const std::vector<uint8_t> extra, bool trusted_daemon);
+    std::vector<wallet2::pending_tx> create_transactions_all(const cryptonote::account_public_address &address, const size_t fake_outs_count, const uint64_t unlock_time, uint64_t fee_multiplier, const std::vector<uint8_t> extra, bool trusted_daemon);
     std::vector<pending_tx> create_unmixable_sweep_transactions(bool trusted_daemon);
     bool check_connection();
     void get_transfers(wallet2::transfer_container& incoming_transfers) const;
@@ -363,6 +363,8 @@ namespace tools
     void store_tx_info(bool store) { m_store_tx_info = store; }
     uint32_t default_mixin() const { return m_default_mixin; }
     void default_mixin(uint32_t m) { m_default_mixin = m; }
+    uint32_t get_default_fee_multiplier() const { return m_default_fee_multiplier; }
+    void set_default_fee_multiplier(uint32_t m) { m_default_fee_multiplier = m; }
     bool auto_refresh() const { return m_auto_refresh; }
     void auto_refresh(bool r) { m_auto_refresh = r; }
 
@@ -423,6 +425,7 @@ namespace tools
     uint64_t get_upper_tranaction_size_limit();
     void check_pending_txes();
     std::vector<uint64_t> get_unspent_amounts_vector();
+    uint64_t sanitize_fee_multiplier(uint64_t fee_multiplier) const;
 
     cryptonote::account_base m_account;
     std::string m_daemon_address;
@@ -455,6 +458,7 @@ namespace tools
     bool m_always_confirm_transfers;
     bool m_store_tx_info; /*!< request txkey to be returned in RPC, and store in the wallet cache file */
     uint32_t m_default_mixin;
+    uint32_t m_default_fee_multiplier;
     RefreshType m_refresh_type;
     bool m_auto_refresh;
     uint64_t m_refresh_from_block_height;

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -56,6 +56,7 @@ namespace tools
     //       file_read_error
     //       file_save_error
     //       invalid_password
+    //       invalid_fee_multiplier
     //       refresh_error *
     //         acc_outs_lookup_error
     //         block_parse_error
@@ -221,6 +222,15 @@ namespace tools
     {
       explicit invalid_password(std::string&& loc)
         : wallet_logic_error(std::move(loc), "invalid password")
+      {
+      }
+
+      std::string to_string() const { return wallet_logic_error::to_string(); }
+    };
+    struct invalid_fee_multiplier : public wallet_logic_error
+    {
+      explicit invalid_fee_multiplier(std::string&& loc)
+        : wallet_logic_error(std::move(loc), "invalid fee multiplier")
       {
       }
 

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -232,7 +232,7 @@ namespace tools
         LOG_PRINT_L1("Requested mixin " << req.mixin << " too low for hard fork 2, using 2");
         mixin = 2;
       }
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions(dsts, mixin, req.unlock_time, req.fee, extra, req.trusted_daemon);
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions(dsts, mixin, req.unlock_time, req.fee_multiplier, extra, req.trusted_daemon);
 
       // reject proposed transactions if there are more than one.  see on_transfer_split below.
       if (ptx_vector.size() != 1)
@@ -299,9 +299,9 @@ namespace tools
       }
       std::vector<wallet2::pending_tx> ptx_vector;
       if (req.new_algorithm)
-        ptx_vector = m_wallet.create_transactions_2(dsts, mixin, req.unlock_time, req.fee, extra, req.trusted_daemon);
+        ptx_vector = m_wallet.create_transactions_2(dsts, mixin, req.unlock_time, req.fee_multiplier, extra, req.trusted_daemon);
       else
-        ptx_vector = m_wallet.create_transactions(dsts, mixin, req.unlock_time, req.fee, extra, req.trusted_daemon);
+        ptx_vector = m_wallet.create_transactions(dsts, mixin, req.unlock_time, req.fee_multiplier, extra, req.trusted_daemon);
 
       m_wallet.commit_tx(ptx_vector);
 
@@ -406,7 +406,7 @@ namespace tools
 
     try
     {
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions_all(dsts[0].addr, req.mixin, req.unlock_time, req.fee, extra, req.trusted_daemon);
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions_all(dsts[0].addr, req.mixin, req.unlock_time, req.fee_multiplier, extra, req.trusted_daemon);
 
       m_wallet.commit_tx(ptx_vector);
 

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -110,7 +110,7 @@ namespace wallet_rpc
     struct request
     {
       std::list<transfer_destination> destinations;
-      uint64_t fee;
+      uint64_t fee_multiplier;
       uint64_t mixin;
       uint64_t unlock_time;
       std::string payment_id;
@@ -119,7 +119,7 @@ namespace wallet_rpc
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)
-        KV_SERIALIZE(fee)
+        KV_SERIALIZE(fee_multiplier)
         KV_SERIALIZE(mixin)
         KV_SERIALIZE(unlock_time)
         KV_SERIALIZE(payment_id)
@@ -145,7 +145,7 @@ namespace wallet_rpc
     struct request
     {
       std::list<transfer_destination> destinations;
-      uint64_t fee;
+      uint64_t fee_multiplier;
       uint64_t mixin;
       uint64_t unlock_time;
       std::string payment_id;
@@ -155,7 +155,7 @@ namespace wallet_rpc
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)
-        KV_SERIALIZE(fee)
+        KV_SERIALIZE(fee_multiplier)
         KV_SERIALIZE(mixin)
         KV_SERIALIZE(unlock_time)
         KV_SERIALIZE(payment_id)
@@ -207,7 +207,7 @@ namespace wallet_rpc
     struct request
     {
       std::string address;
-      uint64_t fee;
+      uint64_t fee_multiplier;
       uint64_t mixin;
       uint64_t unlock_time;
       std::string payment_id;
@@ -216,7 +216,7 @@ namespace wallet_rpc
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
-        KV_SERIALIZE(fee)
+        KV_SERIALIZE(fee_multiplier)
         KV_SERIALIZE(mixin)
         KV_SERIALIZE(unlock_time)
         KV_SERIALIZE(payment_id)


### PR DESCRIPTION
Fee can now be multiplied by 2 or 3, if users want to give
priority to their transactions. There are only three levels
to avoid too much fingerprinting. Default is 1 (minimum fee).
The default multiplier can be set by "set fee-multiplier X".