### PR TITLE
cmake: pass -fno-strict-aliasing to fix build with GCC 6.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,6 +350,11 @@ else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11 -D_GNU_SOURCE ${MINGW_FLAG} ${STATIC_ASSERT_FLAG} ${WARNINGS} ${C_WARNINGS} ${ARCH_FLAG}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -D_GNU_SOURCE ${MINGW_FLAG} ${WARNINGS} ${CXX_WARNINGS} ${ARCH_FLAG}")
 
+  # With GCC 6.1.1 the compiled binary malfunctions due to aliasing. Until that
+  # is fixed in the code (Issue #847), force compiler to be conservative.
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-strict-aliasing")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
+
   option(NO_AES "Explicitly disable AES support" ${NO_AES})
 
   if(NOT NO_AES AND NOT (ARM6 OR ARM7))


### PR DESCRIPTION
This patch is a temprorary workaround until aliasing is fixed in the
code (Issue #847).