### PR TITLE
daemonizer: posix: keep parent's working dir and umask

### DIFF
--- a/src/daemonizer/posix_fork.cpp
+++ b/src/daemonizer/posix_fork.cpp
@@ -50,20 +50,6 @@ void fork()
   // terminal.
   setsid();
 
-  // A process inherits its working directory from its parent. This could be
-  // on a mounted filesystem, which means that the running daemon would
-  // prevent this filesystem from being unmounted. Changing to the root
-  // directory avoids this problem.
-  if (chdir("/") < 0)
-  {
-    quit("Unable to change working directory to root");
-  }
-
-  // The file mode creation mask is also inherited from the parent process.
-  // We don't want to restrict the permissions on files created by the
-  // daemon, so the mask is cleared.
-  umask(0);
-
   // A second fork ensures the process cannot acquire a controlling terminal.
   if (pid_t pid = ::fork())
   {


### PR DESCRIPTION
Keep the working directory (and umask) inherited from
the parent. Otherwise, it's impossible to control
the working directory of the daemon (from systemd, for
example).

Furthermoer, bitmonerod attempts to create logging directories and files
*in current working directory*. This fails due to permission denied and
generates a (caught, nonfatal) exception. Below is the strace with this
patch applied (so, no `chdir("/")`), showing successful opens at `log/`
relative path. Without this patch they fail (sorry, didn't save the
trace).

```
28911 getcwd("/.../bitmonero", 128) = 25
28911 stat64("/var/lib/bitmonero/.bitmonero", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
28911 stat64("/etc/bitmonerod.conf", {st_mode=S_IFREG|0644, st_size=244, ...}) = 0
28911 open("/etc/bitmonerod.conf", O_RDONLY|O_LARGEFILE) = 3
28911 open("/var/log/bitmonero/bitmonero.log", O_WRONLY|O_CREAT|O_APPEND|O_LARGEFILE, 0666) = 3
28911 stat64("log", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
28911 stat64("log/dbg", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
28911 open("log/dbg/main.log", O_WRONLY|O_CREAT|O_TRUNC|O_LARGEFILE, 0666) = 4
```
The reasoning of chdir("/") in order to prevent the daemon from holding
a filesystem in busy state is not compelling at all: the choice of
working directory for the daemon is the user's business not the
daemon's.