### PR TITLE
Implement Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ addons:
     - libunwind8-dev
     #sources:
     #- ubuntu-toolchain-r-test
-script: make -j2 && make -j2 release-test && HAVE_DOT=YES doxygen Doxyfile
+script: make -j2 && HAVE_DOT=YES doxygen Doxyfile
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+sudo: required
+dist: trusty
+language: cpp
+compiler:
+- gcc
+addons:
+  apt:
+    packages:
+    - build-essential
+    - cmake
+    - doxygen
+    - g++
+    - gcc
+    - graphviz
+    - libboost1.55-all-dev
+    - libdb++-dev
+    - libdb-dev
+    - libgtest-dev
+    - libminiupnpc-dev
+    - libssl-dev
+    - libssl1.0.0
+    - libunbound-dev
+    - libunwind8-dev
+    #sources:
+    #- ubuntu-toolchain-r-test
+script: make -j2 && make -j2 release-test && HAVE_DOT=YES doxygen Doxyfile
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Copyright (c) 2014-2016, The Monero Project
 
+[![Build Status](https://travis-ci.org/anonimal/bitmonero.svg?branch=master)](https://travis-ci.org/anonimal/bitmonero)
+
 ## Development Resources
 
 Web: [getmonero.org](https://getmonero.org)  

--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@ Copyright (c) 2014-2016, The Monero Project
 
 ## Development Resources
 
-Web: [getmonero.org](https://getmonero.org)  
-Forum: [forum.getmonero.org](https://forum.getmonero.org)  
-Mail: [dev@getmonero.org](mailto:dev@getmonero.org)  
-Github (staging): [https://github.com/monero-project/bitmonero](https://github.com/monero-project/bitmonero)  
-Github (development): [http://github.com/monero-project/bitmonero/tree/development](http://github.com/monero-project/bitmonero/tree/development)  
+Web: [getmonero.org](https://getmonero.org)
+Forum: [forum.getmonero.org](https://forum.getmonero.org)
+Mail: [dev@getmonero.org](mailto:dev@getmonero.org)
+GitHub: [https://github.com/monero-project/bitmonero](https://github.com/monero-project/bitmonero)
 IRC: [#monero-dev on Freenode](irc://chat.freenode.net/#monero-dev)
 
 ## Introduction


### PR DESCRIPTION
Here is a baseline Travis-CI configuration.

In the future, we should further develop a build matrix to suit our needs: expand build options, multiple compilers and versions, etc. but, for now, this minimal configuration can (at the very least) provide an easy way to see if PR's build successfully.

I've excluded the static build option because of #907 but we should consider adding the static build once the issue is resolved. Also, because of #906, I've included boost 1.55 as our boost-of-choice despite 1.54 building successfully.

Currently, the status badge points to [anonimal/bitmonero](https://travis-ci.org/anonimal/bitmonero) but that should be changed once @fluffypony or any repo owner signs-up for Travis-CI.

Sign-up should be simple as it's already been done for Kovri. Here are some quick steps:

- Go to https://travis-ci.org
- Sign-in with GitHub
- Go to https://travis-ci.org/profile/monero-project
- Flick on ```monero-project/bitmonero```

Voila!

If I can get confirmation that monero-project has signed up for Travis-CI, I'll update the status badge in this PR.