### PR TITLE
Remove build badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Copyright (c) 2014-2016, The Monero Project
 
-[![Build Status](https://travis-ci.org/monero-project/bitmonero.svg?branch=master)](https://travis-ci.org/monero-project/bitmonero)
-
 ## Development Resources
 
 - Web: [getmonero.org](https://getmonero.org)


### PR DESCRIPTION
If the build badge is going to be left red for extended periods of time we shouldn't keep it in the readme.  It leads people visiting the project to believe it's in a state of disrepair.