### PR TITLE
Build: remove libunbound-dev from Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ addons:
     - libminiupnpc-dev
     - libssl-dev
     - libssl1.0.0
-    - libunbound-dev
     - libunwind8-dev
     #sources:
     #- ubuntu-toolchain-r-test


### PR DESCRIPTION
* Also fixes broken build on Ubuntu 14.04