### PR TITLE
cmake: wallet: fix cmake error related to libunbound is not always static

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -75,28 +75,10 @@ target_link_libraries(wallet
     ${Boost_REGEX_LIBRARY}
     ${EXTRA_LIBRARIES})
 
-    
-# in case of static build, randon.c.obj from UNBOUND_LIBARY conflicts with the same file from 'crypto'
-# and in case of dynamic build, merge_static_libs called with ${UNBOUND_LIBRARY} will fail
-if (STATIC) 
-    set(libs_to_merge wallet cryptonote_core mnemonics common crypto) 
-    # hack - repack libunbound into another static lib - there's conflicting object file "random.c.obj"
-    merge_static_libs(wallet_merged "${libs_to_merge}")
-    merge_static_libs(wallet_merged2 "${UNBOUND_LIBRARY}")
-    install(TARGETS wallet_merged wallet_merged2
-        ARCHIVE DESTINATION lib)
-else (STATIC)
-    set(libs_to_merge wallet cryptonote_core mnemonics common crypto ${UNBOUND_LIBRARY} ) 
-    merge_static_libs(wallet_merged "${libs_to_merge}")
-    install(TARGETS wallet_merged
-        ARCHIVE DESTINATION lib)
-endif (STATIC)
-
-#MERGE_STATIC_LIBS(wallet_merged wallet_merged "${libs_to_merge}")
-
-
+set(libs_to_merge wallet cryptonote_core mnemonics common crypto)
+merge_static_libs(wallet_merged "${libs_to_merge}")
+install(TARGETS wallet_merged
+    ARCHIVE DESTINATION lib)
 
 install(FILES ${wallet_api_headers}
     DESTINATION include/wallet)
-
-


### PR DESCRIPTION
This fixes this error which (presumably) was introduced with #915:
```
CMake Error at cmake/MergeStaticLibs.cmake:35 (message):
  Merge_static_libs can only process static libraries
Call Stack (most recent call first):
  src/wallet/CMakeLists.txt:90 (merge_static_libs)
-- Configuring incomplete, errors occurred!
```

Re #915, it is not clear why libunbound was added to this in the first place,
since it wasn't here before and #915 doesn't seem to introduce any
new dependency on it.

Tested build with STATIC=OFF (with and without libunbound-dev libunbound8
installed) and STATIC=ON, on Ubuntu Trusty, Debian Jessie, and Arch
Linux. For static builds, beware of #926 and #907.

If this hack was introduced to make it build on some other system
(Windows? OS X?), then it will have to be dealt with, but not this way.

**NOTE**: #925 should not be necessary after this PR.