### PR TITLE
wallet: new {ex,im}port_key_images commands and RPC calls

### DIFF
--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -145,6 +145,8 @@ namespace cryptonote
     bool set_default_fee_multiplier(const std::vector<std::string> &args);
     bool sign(const std::vector<std::string> &args);
     bool verify(const std::vector<std::string> &args);
+    bool export_key_images(const std::vector<std::string> &args);
+    bool import_key_images(const std::vector<std::string> &args);
 
     uint64_t get_daemon_blockchain_height(std::string& err);
     bool try_connect_to_daemon(bool silent = false);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -394,8 +394,10 @@ namespace tools
     std::string sign(const std::string &data) const;
     bool verify(const std::string &data, const cryptonote::account_public_address &address, const std::string &signature) const;
 
-    void update_pool_state();
+    std::vector<std::pair<crypto::key_image, crypto::signature>> export_key_images() const;
+    uint64_t import_key_images(const std::vector<std::pair<crypto::key_image, crypto::signature>> &signed_key_images, uint64_t &spent, uint64_t &unspent);
 
+    void update_pool_state();
   private:
     /*!
      * \brief  Stores wallet information to wallet file.

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -82,6 +82,8 @@ namespace tools
         MAP_JON_RPC_WE("get_transfers",      on_get_transfers,      wallet_rpc::COMMAND_RPC_GET_TRANSFERS)
         MAP_JON_RPC_WE("sign",               on_sign,               wallet_rpc::COMMAND_RPC_SIGN)
         MAP_JON_RPC_WE("verify",             on_verify,             wallet_rpc::COMMAND_RPC_VERIFY)
+        MAP_JON_RPC_WE("export_key_images",  on_export_key_images,  wallet_rpc::COMMAND_RPC_EXPORT_KEY_IMAGES)
+        MAP_JON_RPC_WE("import_key_images",  on_import_key_images,  wallet_rpc::COMMAND_RPC_IMPORT_KEY_IMAGES)
       END_JSON_RPC_MAP()
     END_URI_MAP2()
 
@@ -107,6 +109,8 @@ namespace tools
       bool on_get_transfers(const wallet_rpc::COMMAND_RPC_GET_TRANSFERS::request& req, wallet_rpc::COMMAND_RPC_GET_TRANSFERS::response& res, epee::json_rpc::error& er);
       bool on_sign(const wallet_rpc::COMMAND_RPC_SIGN::request& req, wallet_rpc::COMMAND_RPC_SIGN::response& res, epee::json_rpc::error& er);
       bool on_verify(const wallet_rpc::COMMAND_RPC_VERIFY::request& req, wallet_rpc::COMMAND_RPC_VERIFY::response& res, epee::json_rpc::error& er);
+      bool on_export_key_images(const wallet_rpc::COMMAND_RPC_EXPORT_KEY_IMAGES::request& req, wallet_rpc::COMMAND_RPC_EXPORT_KEY_IMAGES::response& res, epee::json_rpc::error& er);
+      bool on_import_key_images(const wallet_rpc::COMMAND_RPC_IMPORT_KEY_IMAGES::request& req, wallet_rpc::COMMAND_RPC_IMPORT_KEY_IMAGES::response& res, epee::json_rpc::error& er);
 
       bool handle_command_line(const boost::program_options::variables_map& vm);
 

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -601,5 +601,70 @@ namespace wallet_rpc
     };
   };
 
+  struct COMMAND_RPC_EXPORT_KEY_IMAGES
+  {
+    struct request
+    {
+      BEGIN_KV_SERIALIZE_MAP()
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct signed_key_image
+    {
+      std::string key_image;
+      std::string signature;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(key_image);
+        KV_SERIALIZE(signature);
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      std::vector<signed_key_image> signed_key_images;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(signed_key_images);
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
+  struct COMMAND_RPC_IMPORT_KEY_IMAGES
+  {
+    struct signed_key_image
+    {
+      std::string key_image;
+      std::string signature;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(key_image);
+        KV_SERIALIZE(signature);
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct request
+    {
+      std::vector<signed_key_image> signed_key_images;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(signed_key_images);
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      uint64_t height;
+      uint64_t spent;
+      uint64_t unspent;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(height)
+        KV_SERIALIZE(spent)
+        KV_SERIALIZE(unspent)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
 }
 }

--- a/src/wallet/wallet_rpc_server_error_codes.h
+++ b/src/wallet/wallet_rpc_server_error_codes.h
@@ -40,3 +40,4 @@
 #define WALLET_RPC_ERROR_CODE_DENIED                  -7
 #define WALLET_RPC_ERROR_CODE_WRONG_TXID              -8
 #define WALLET_RPC_ERROR_CODE_WRONG_SIGNATURE         -9
+#define WALLET_RPC_ERROR_CODE_WRONG_KEY_IMAGE        -10


### PR DESCRIPTION
They are used to export a signed set of key images from a wallet
with a private spend key, so an auditor with the matching view key
may see which of those are spent, and which are not.