### PR TITLE
fix #864;  allow password to be entered twice to verify

### DIFF
--- a/src/simplewallet/password_container.cpp
+++ b/src/simplewallet/password_container.cpp
@@ -48,24 +48,25 @@ namespace tools
   {
     bool is_cin_tty();
   }
-
+  // deleted via private member
   password_container::password_container()
-    : m_empty(true)
+    : m_empty(true),m_verify(false)
   {
+
+  }
+  password_container::password_container(bool verify)
+    : m_empty(true),m_verify(verify)
+  {
+
   }
 
-  password_container::password_container(std::string&& password)
-    : m_empty(false)
-    , m_password(std::move(password))
-  {
-  }
 
   password_container::password_container(password_container&& rhs)
     : m_empty(std::move(rhs.m_empty))
     , m_password(std::move(rhs.m_password))
+    , m_verify(std::move(rhs.m_verify))
   {
   }
-
   password_container::~password_container()
   {
     clear();
@@ -88,9 +89,7 @@ namespace tools
     bool r;
     if (is_cin_tty())
     {
-      if (message)
-        std::cout << message << ": ";
-      r = read_from_tty();
+     r = read_from_tty_double_check(message);
     }
     else
     {
@@ -132,6 +131,43 @@ namespace tools
     return true;
   }
 
+bool password_container::read_from_tty_double_check(const char *message) {
+    std::string pass1;
+    std::string pass2;
+    bool match=false;
+    bool doNotVerifyEntry=false;
+    do{
+        if (message)
+            std::cout << message <<": ";
+        if (!password_container::read_from_tty(pass1))
+            return false;
+        if (m_verify==true){//double check password; 
+            if (message)
+                std::cout << message << ": ";
+            if (!password_container::read_from_tty(pass2))
+                return false;
+            if(pass1!=pass2){ //new password entered did not match
+
+                std::cout << "Passwords do not match" << std::endl;
+                pass1="";
+                pass2="";
+                match=false;
+            }
+            else{//new password matches
+                match=true;
+            }
+        }
+        else
+            doNotVerifyEntry=true; //do not verify
+            //No need to verify password entered at this point in the code 
+            
+    }while(match==false && doNotVerifyEntry==false);
+
+    m_password=pass1;
+    return true;
+  }
+
+
 #if defined(_WIN32)
 
   namespace
@@ -142,7 +178,7 @@ namespace tools
     }
   }
 
-  bool password_container::read_from_tty()
+  bool password_container::read_from_tty(std::string & pass)
   {
     const char BACKSPACE = 8;
 
@@ -154,8 +190,8 @@ namespace tools
     ::SetConsoleMode(h_cin, mode_new);
 
     bool r = true;
-    m_password.reserve(max_password_size);
-    while (m_password.size() < max_password_size)
+    pass.reserve(max_password_size);
+    while (pass.size() < max_password_size)
     {
       DWORD read;
       char ch;
@@ -172,16 +208,16 @@ namespace tools
       }
       else if (ch == BACKSPACE)
       {
-        if (!m_password.empty())
+        if (!pass.empty())
         {
-          m_password.back() = '\0';
-          m_password.resize(m_password.size() - 1);
+          pass.back() = '\0';
+          pass.resize(pass.size() - 1);
           std::cout << "\b \b";
         }
       }
       else
       {
-        m_password.push_back(ch);
+        pass.push_back(ch);
         std::cout << '*';
       }
     }
@@ -217,13 +253,12 @@ namespace tools
       return ch;
     }
   }
-
-  bool password_container::read_from_tty()
+  bool password_container::read_from_tty(std::string &aPass)
   {
     const char BACKSPACE = 127;
 
-    m_password.reserve(max_password_size);
-    while (m_password.size() < max_password_size)
+    aPass.reserve(max_password_size);
+    while (aPass.size() < max_password_size)
     {
       int ch = getch();
       if (EOF == ch)
@@ -237,16 +272,16 @@ namespace tools
       }
       else if (ch == BACKSPACE)
       {
-        if (!m_password.empty())
+        if (!aPass.empty())
         {
-          m_password.back() = '\0';
-          m_password.resize(m_password.size() - 1);
+          aPass.back() = '\0';
+          aPass.resize(aPass.size() - 1);
           std::cout << "\b \b";
         }
       }
       else
       {
-        m_password.push_back(ch);
+        aPass.push_back(ch);
         std::cout << '*';
       }
     }

--- a/src/simplewallet/password_container.h
+++ b/src/simplewallet/password_container.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <string>
+#include <boost/program_options/variables_map.hpp>
 
 namespace tools
 {
@@ -38,9 +39,7 @@ namespace tools
   {
   public:
     static const size_t max_password_size = 1024;
-
-    password_container();
-    password_container(std::string&& password);
+    password_container(bool verify);
     password_container(password_container&& rhs);
     ~password_container();
 
@@ -51,11 +50,14 @@ namespace tools
     bool read_password(const char *message = "password");
 
   private:
+    //delete constructor with no parameters
+    password_container();
     bool read_from_file();
-    bool read_from_tty();
+    bool read_from_tty(std::string & pass);
+    bool read_from_tty_double_check(const char *message);
 
-  private:
     bool m_empty;
     std::string m_password;
+    bool m_verify;
   };
 }

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -33,7 +33,6 @@
  * 
  * \brief Source file that defines simple_wallet class.
  */
-
 #include <thread>
 #include <iostream>
 #include <sstream>
@@ -348,7 +347,11 @@ bool simple_wallet::seed_set_language(const std::vector<std::string> &args/* = s
     fail_msg_writer() << tr("wallet is non-deterministic and has no seed");
     return true;
   }
-  tools::password_container pwd_container;
+  bool verify=false;
+  if(m_wallet_file.empty())
+    verify=true;
+ 
+  tools::password_container pwd_container(verify);
   success = pwd_container.read_password();
   if (!success)
   {
@@ -380,7 +383,10 @@ bool simple_wallet::set_always_confirm_transfers(const std::vector<std::string> 
     fail_msg_writer() << tr("wallet is watch-only and cannot transfer");
     return true;
   }
-  tools::password_container pwd_container;
+  bool verify=false;
+  if(m_wallet_file.empty()==true)
+        verify=true;
+  tools::password_container pwd_container(verify);
   success = pwd_container.read_password();
   if (!success)
   {
@@ -409,7 +415,11 @@ bool simple_wallet::set_store_tx_info(const std::vector<std::string> &args/* = s
     fail_msg_writer() << tr("wallet is watch-only and cannot transfer");
     return true;
   }
-  tools::password_container pwd_container;
+  bool verify=false;
+  if(m_wallet_file.empty())
+     verify=true;
+ 
+  tools::password_container pwd_container(verify);
   success = pwd_container.read_password();
   if (!success)
   {
@@ -453,8 +463,11 @@ bool simple_wallet::set_default_mixin(const std::vector<std::string> &args/* = s
     }
     if (mixin == 0)
       mixin = DEFAULT_MIX;
-
-    tools::password_container pwd_container;
+    bool verify=false;
+    if(m_wallet_file.empty())
+      verify=true;
+ 
+    tools::password_container pwd_container(verify);
     success = pwd_container.read_password();
     if (!success)
     {
@@ -515,8 +528,11 @@ bool simple_wallet::set_default_fee_multiplier(const std::vector<std::string> &a
         return true;
       }
     }
-
-    tools::password_container pwd_container;
+    bool verify=false;
+    if(m_wallet_file.empty())
+      verify=true;
+ 
+    tools::password_container pwd_container(verify);
     success = pwd_container.read_password();
     if (!success)
     {
@@ -551,7 +567,11 @@ bool simple_wallet::set_default_fee_multiplier(const std::vector<std::string> &a
 bool simple_wallet::set_auto_refresh(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
   bool success = false;
-  tools::password_container pwd_container;
+  bool verify=false;
+  if(m_wallet_file.empty()==true)
+        verify=true;
+ 
+  tools::password_container pwd_container(verify);
   success = pwd_container.read_password();
   if (!success)
   {
@@ -594,8 +614,11 @@ bool simple_wallet::set_refresh_type(const std::vector<std::string> &args/* = st
   {
     return true;
   }
-
-  tools::password_container pwd_container;
+  bool verify=false;
+  if(m_wallet_file.empty())
+     verify=true;
+ 
+  tools::password_container pwd_container(verify);
   success = pwd_container.read_password();
   if (!success)
   {
@@ -894,7 +917,7 @@ void simple_wallet::print_seed(std::string seed)
 }
 
 //----------------------------------------------------------------------------------------------------
-static bool get_password(const boost::program_options::variables_map& vm, bool allow_entry, tools::password_container &pwd_container)
+bool simple_wallet::get_password(const boost::program_options::variables_map& vm, bool allow_entry, tools::password_container &pwd_container)
 {
   // has_arg returns true even when the parameter is not passed ??
   const std::string gfj = command_line::get_arg(vm, arg_generate_from_json);
@@ -935,6 +958,8 @@ static bool get_password(const boost::program_options::variables_map& vm, bool a
 
   if (allow_entry)
   {
+      //vm is already part of the password container class.  just need to check vm for an already existing wallet
+      //here need to pass in variable map.  This will indicate if the wallet already exists to the read password function
     bool r = pwd_container.read_password();
     if (!r)
     {
@@ -1220,9 +1245,11 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
     }
   }
   catch (const std::exception &e) { }
-
-  tools::password_container pwd_container;
-  if (!get_password(vm, true, pwd_container))
+  bool verify=false;
+  if(m_wallet_file.empty())
+      verify=true;
+  tools::password_container pwd_container(verify); //m_wallet_file will be empty at this point for new wallets
+  if (!cryptonote::simple_wallet::get_password(vm, true, pwd_container))
     return false;
 
   if (!m_generate_new.empty() || m_restore_deterministic_wallet || !m_generate_from_view_key.empty() || !m_generate_from_keys.empty() || !m_generate_from_json.empty())
@@ -1761,7 +1788,10 @@ bool simple_wallet::save(const std::vector<std::string> &args)
 bool simple_wallet::save_watch_only(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
   bool success = false;
-  tools::password_container pwd_container;
+  bool verify=false;
+  if(m_wallet_file.empty())
+      verify=true;
+  tools::password_container pwd_container(verify);
 
   success = pwd_container.read_password(tr("Password for the new watch-only wallet"));
   if (!success)
@@ -3617,8 +3647,12 @@ int main(int argc, char* argv[])
     bool testnet = command_line::get_arg(vm, arg_testnet);
     bool restricted = command_line::get_arg(vm, arg_restricted);
     std::string wallet_file     = command_line::get_arg(vm, arg_wallet_file);
-    tools::password_container pwd_container;
-    if (!get_password(vm, false, pwd_container))
+    bool verify=false;
+    if(wallet_file.empty())
+      verify=true;
+ 
+    tools::password_container pwd_container(verify);
+    if (!cryptonote::simple_wallet::get_password(vm, false, pwd_container))
       return 1;
     std::string daemon_address  = command_line::get_arg(vm, arg_daemon_address);
     std::string daemon_host = command_line::get_arg(vm, arg_daemon_host);

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -58,6 +58,7 @@ namespace cryptonote
   class simple_wallet : public tools::i_wallet2_callback
   {
   public:
+    static bool get_password(const boost::program_options::variables_map& vm, bool allow_entry, tools::password_container &pwd_container);
     static const char *tr(const char *str) { return i18n_translate(str, "cryptonote::simple_wallet"); }
 
   public:


### PR DESCRIPTION
Password prompt will show up once if the wallet exists.
Password prompt will show up twice if the wallet does not exist.
Cleaned up an extra constructor that only took a password.  It was not being used.
Squashed commits into one commit.

Let me know.