### PR TITLE
Build: add release-test and clang support to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: trusty
 language: cpp
 compiler:
 - gcc
+- clang
 addons:
   apt:
     packages:
@@ -11,6 +12,7 @@ addons:
     - doxygen
     - g++
     - gcc
+    - clang
     - graphviz
     - libboost1.55-all-dev
     - libdb++-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
     - libunwind8-dev
     #sources:
     #- ubuntu-toolchain-r-test
-script: make -j2 && HAVE_DOT=YES doxygen Doxyfile
+script: make -j2 && travis_wait make -j2 release-test && HAVE_DOT=YES doxygen Doxyfile
 notifications:
   email: false
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ addons:
     - libunwind8-dev
     #sources:
     #- ubuntu-toolchain-r-test
-script: make -j2 && travis_wait make -j2 release-test && HAVE_DOT=YES doxygen Doxyfile
+script: make -j2 && HAVE_DOT=YES doxygen Doxyfile
 notifications:
   email: false
   irc:


### PR DESCRIPTION
Knowing Travis CI, this may take a few more commits to fine-tune.

Referencing https://github.com/monero-project/bitmonero/blob/master/CMakeLists.txt#L415