### PR TITLE
Fix#864 - prompt for password twice

### DIFF
--- a/src/simplewallet/password_container.h
+++ b/src/simplewallet/password_container.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <string>
+#include <boost/program_options/variables_map.hpp>
 
 namespace tools
 {
@@ -38,10 +39,9 @@ namespace tools
   {
   public:
     static const size_t max_password_size = 1024;
-
-    password_container();
-    password_container(std::string&& password);
+    password_container(bool verify);
     password_container(password_container&& rhs);
+    password_container(std::string&& password);
     ~password_container();
 
     void clear();
@@ -51,11 +51,14 @@ namespace tools
     bool read_password(const char *message = "password");
 
   private:
+    //delete constructor with no parameters
+    password_container();
     bool read_from_file();
-    bool read_from_tty();
+    bool read_from_tty(std::string & pass);
+    bool read_from_tty_double_check(const char *message);
 
-  private:
     bool m_empty;
     std::string m_password;
+    bool m_verify;
   };
 }

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -58,6 +58,7 @@ namespace cryptonote
   class simple_wallet : public tools::i_wallet2_callback
   {
   public:
+    static bool get_password(const boost::program_options::variables_map& vm, bool allow_entry, tools::password_container &pwd_container);
     static const char *tr(const char *str) { return i18n_translate(str, "cryptonote::simple_wallet"); }
 
   public:


### PR DESCRIPTION
commit 9af9e4223b58bbb65a3519af2c2bfc273cbd23d6
Author: guzzi_jones <guzzijones12@gmail.com>
Date:   Mon Aug 1 00:00:19 2016 +0000

    fixed some formatting

commit c7920e1cf88ff46eb9294101344d9a567f22e2da
Merge: 97eb28b 1da1c68
Author: guzzi_jones <guzzijones12@gmail.com>
Date:   Sun Jul 31 23:36:24 2016 +0000

    fix#864 fix using boolean

commit 97eb28ba5dd49ddde8c8785f39b24d955e5de31c
Author: EC2 Default User <ec2-user@ip-172-31-47-165.us-west-2.compute.internal>
Date:   Sun Jul 24 02:08:10 2016 +0000

    Fix #864 boolean value used to verify on new wallet

commit 1da1c68bd3a9a373c70482b6e6e95251096149f1
Author: guzzi_jones <guzzijones12@gmail.com>
Date:   Sun Jul 31 21:47:43 2016 +0000

    fix #864 changed to boolean to prompt for verify

commit 5bee96652434762d2c91ce31a1b1c9f169446ddc
Author: guzzi_jones <ec2-user@ip-172-31-47-165.us-west-2.compute.internal>
Date:   Sat Jul 30 00:32:35 2016 +0000

    fix 864; made variable names easier for understanding branching.

commit 45715960d30293f781b2ff9e5e647c2ec893f4a3
Author: EC2 Default User <ec2-user@ip-172-31-47-165.us-west-2.compute.internal>
Date:   Sun Jul 24 02:08:10 2016 +0000

    fix #864;  allow password to be entered twice for new wallets for verification.

fix #864 password entry verification; amended Boolean