### PR TITLE
daemon: fix exception spam on stdout

### DIFF
--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -42,10 +42,7 @@
 #include "rpc/core_rpc_server.h"
 #include "daemon/command_line_args.h"
 #include "blockchain_db/db_types.h"
-
-#ifdef STACK_TRACE
 #include "common/stack_trace.h"
-#endif // STACK_TRACE
 
 namespace po = boost::program_options;
 namespace bf = boost::filesystem;
@@ -272,9 +269,7 @@ int main(int argc, char const * argv[])
         , log_file_path.filename().string().c_str()
         , log_file_path.parent_path().string().c_str()
         );
-#ifdef STACK_TRACE
       tools::set_stack_trace_log(log_file_path.filename().string());
-#endif // STACK_TRACE
     }
 
     if (command_line::has_arg(vm, daemon_args::arg_max_concurrency))


### PR DESCRIPTION
The stack_trace.h header can be included in all cases since it
doesn't use anything from libunwind, and the set_stack_trace_log
function can be called in all cases since it just sets a global
variable.