### PR TITLE
Add ARMv8 handling to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,12 @@ if ("${ARCH}" STREQUAL "" OR "${ARCH}" STREQUAL "native")
 endif()
 
 if (NOT "${ARCH}" STREQUAL "")
+  if ("${ARCH}" STREQUAL "aarch64") #Detect ARMv8
+    set(ARM8 1)
+  else()
+    set(ARM8 0)
+  endif()
+
   string(SUBSTRING ${ARCH} 0 3 IS_ARM)
   string(TOLOWER ${IS_ARM} IS_ARM)
 
@@ -72,7 +78,7 @@ if (NOT "${ARCH}" STREQUAL "")
   endif()
 endif()
 
-if(WIN32 OR ARM7 OR ARM6)
+if(WIN32 OR ARM7 OR ARM6) #ARM8 may benefit from vectorisation
   set(OPT_FLAGS_RELEASE "-O2")
 else()
   set(OPT_FLAGS_RELEASE "-Ofast")
@@ -314,7 +320,7 @@ if(MSVC)
 else()
   set(ARCH native CACHE STRING "CPU to build for: -march value or default")
   # -march=armv7-a conflicts with -mcpu=cortex-a7
-  if(ARCH STREQUAL "default" OR ARM7 OR ARM6)
+  if(ARCH STREQUAL "default" OR ARM8 OR ARM7 OR ARM6)
     set(ARCH_FLAG "")
   else()
     if(ARCH STREQUAL "x86_64")
@@ -366,27 +372,89 @@ else()
 
   option(NO_AES "Explicitly disable AES support" ${NO_AES})
 
-  if(NOT NO_AES AND NOT (ARM6 OR ARM7))
+  if(NOT NO_AES AND NOT (ARM6 OR ARM7 OR ARM8))
     message(STATUS "AES support enabled")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -maes")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -maes")
   elseif(ARM7 OR ARM6)
-    message(STATUS "AES support disabled (not available on ARM)")
+    message(STATUS "AES support disabled (not available on ARMv6 or ARMv7)")
   else()
     message(STATUS "AES support disabled")
   endif()
 
+  if(ARM6 OR ARM7 OR ARM8)
+  message(STATUS "Setting FPU Flags for ARM Processors")
+  include(TestCXXAcceptsFlag)
+
+  #NB NEON hardware does not fully implement the IEEE 754 standard for floating-point arithmetic
+  #No point implementing NEON SIMD flags until custom assembly code written
+  #Cortex-A5/9  -mfpu=neon-fp16
+  #Cortex-A7/15 -mfpu=neon-vfpv4
+  #Cortex-A8    -mfpu=neon
+  #For future reference, processor IDs for ARMv8-A series:
+  #0xd04 - Cortex-A35
+  #0xd07 - Cortex-A57
+  #0xd08 - Cortex-A72
+  #0xd03 - Cortex-A73
+
+  #CHECK_CXX_ACCEPTS_FLAG(-ffast-math CXX_ACCEPTS_FFAST_MATH) #For SIMD
+  CHECK_CXX_ACCEPTS_FLAG(-mfpu=vfp3-d16 CXX_ACCEPTS_VFP3_D16)
+  CHECK_CXX_ACCEPTS_FLAG(-mfpu=vfp4 CXX_ACCEPTS_VFP4)
+  CHECK_CXX_ACCEPTS_FLAG(-mfloat-abi=hard CXX_ACCEPTS_MFLOAT_HARD)
+  CHECK_CXX_ACCEPTS_FLAG(-mfloat-abi=softfp CXX_ACCEPTS_MFLOAT_SOFTFP)
+  CHECK_CXX_ACCEPTS_FLAG(-mfix-cortex-a53-835769 CXX_ACCEPTS_MFIX_CORTEX_A53_835769)
+  CHECK_CXX_ACCEPTS_FLAG(-mfix-cortex-a53-843419 CXX_ACCEPTS_MFIX_CORTEX_A53_843419)
+  CHECK_CXX_ACCEPTS_FLAG(-mtune=native CXX_ACCEPTS_MTUNE_NATIVE)
+
   if(ARM6)
-    message(STATUS "Setting ARM6 C and C++ flags")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpu=vfp -mfloat-abi=hard")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=vfp -mfloat-abi=hard")
+    message(STATUS "Selecting VFP")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpu=vfp")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=vfp")
   endif()
 
-  if(ARM7)
-    message(STATUS "Setting ARM7 C and C++ flags")
+  if(CXX_ACCEPTS_VFP3_D16 AND NOT CXX_ACCEPTS_VFP4)
+    message(STATUS "Selecting VFP3")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpu=vfp3-d16")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=vfp3-d16")
+  endif()
+
+  if(CXX_ACCEPTS_VFP4)
+    message(STATUS "Selecting VFP4")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpu=vfp4")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=vfp4")
+  endif()
+
+  if(CXX_ACCEPTS_MFLOAT_HARD)
+    message(STATUS "Setting Hardware ABI for Floating Point")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfloat-abi=hard")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfloat-abi=hard")
   endif()
+
+  if(CXX_ACCEPTS_MFLOAT_SOFTFP AND NOT CXX_ACCEPTS_MFLOAT_HARD)
+    message(STATUS "Setting Software ABI for Floating Point")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfloat-abi=softfp")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfloat-abi=softfp")
+  endif()
+
+  if(CXX_ACCEPTS_MFIX_CORTEX_A53_835769)
+    message(STATUS "Enabling Cortex-A53 workaround 835769")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfix-cortex-a53-835769")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfix-cortex-a53-835769")
+  endif()
+
+  if(CXX_ACCEPTS_MFIX_CORTEX_A53_843419)
+    message(STATUS "Enabling Cortex-A53 workaround 843419")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfix-cortex-a53-843419")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfix-cortex-a53-843419")
+  endif()
+
+  if(CXX_ACCEPTS_MTUNE_NATIVE)
+    message(STATUS "Tuning for Native ARM Architecture")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mtune=native")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mtune=native")
+  endif()
+
+  endif(ARM6 OR ARM7 OR ARM8)
 
   if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_HAS_TR1_TUPLE=0")
@@ -515,4 +583,3 @@ if(BUILD_DOCUMENTATION)
       COMMENT "Generating API documentation with Doxygen.." VERBATIM)
   endif()
 endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ if (NOT "${ARCH}" STREQUAL "")
   endif()
 endif()
 
-if(WIN32 OR ARM7 OR ARM6) #ARM8 may benefit from vectorisation
+if(WIN32 OR ARM8 OR ARM7 OR ARM6)
   set(OPT_FLAGS_RELEASE "-O2")
 else()
   set(OPT_FLAGS_RELEASE "-Ofast")

--- a/README.i18n
+++ b/README.i18n
@@ -13,7 +13,7 @@ To update ts files after changing source code:
 
 To add a new language, eg Spanish (ISO code es):
 
-  cp transations/monero.ts transations/monero_es.ts
+  cp translations/monero.ts translations/monero_es.ts
 
 To edit translations for Spanish:
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Monero development can be supported directly through donations.
 
 Both Monero and Bitcoin donations can be made to donate.getmonero.org if using a client that supports the [OpenAlias](https://openalias.org) standard
 
-The Monero donation address is: 44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A (viewkey: f359631075708155cc3d92a32b75a7d02a5dcf27756707b47a2b31b21c389501)
+The Monero donation address is: `44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A` (viewkey: `f359631075708155cc3d92a32b75a7d02a5dcf27756707b47a2b31b21c389501`)
 
-The Bitcoin donation address is: 1KTexdemPdxSBcG55heUuTjDRYqbC5ZL8H
+The Bitcoin donation address is: `1KTexdemPdxSBcG55heUuTjDRYqbC5ZL8H`
 
 Core development funding and/or some supporting services are also graciously provided by sponsors:
 
@@ -244,10 +244,15 @@ TAILS ships with a very restrictive set of firewall rules. Therefore, you need t
 
 ## Using readline
 
+<<<<<<< HEAD
 While bitmonerod and simplewallet do not use readline directly, most of the
 functionality can be obtained by running them via rlwrap. This allows command
 recall, edit capabilities, etc. It does not give autocompletion without an
 extra completion file, however. To use rlwrap, prefix the command with
 `rlwrap`:
+=======
+While bitmonerod and simplewallet do not use readline directly, most of the functionality can be obtained by running them via rlwrap. This allows command recall, edit capabilities, etc. It does not give autocompletion without an extra completion file, however. To use rlwrap, simply prepend `rlwrap` to the command line, eg:
+`rlwrap bin/simplewallet --wallet-file /path/to/wallet`
+>>>>>>> 00bcae4... README formatting
 
     rlwrap bin/simplewallet --wallet-file /path/to/wallet

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Core development funding and/or some supporting services are also graciously pro
 [<img width="150" src="https://static.getmonero.org/images/sponsors/araxis.png"/>](http://araxis.com)
 [<img width="150" src="https://static.getmonero.org/images/sponsors/jetbrains.png"/>](http://www.jetbrains.com/)
 [<img width="150" src="https://static.getmonero.org/images/sponsors/navicat.png"/>](http://www.navicat.com/)
+[<img width="150" src="https://static.getmonero.org/images/sponsors/symas.png"/>](http://www.symas.com/)
 
 There are also several mining pools that kindly donate a portion of their fees, [a list of them can be found on our Bitcointalk post](https://bitcointalk.org/index.php?topic=583449.0).
 
@@ -67,7 +68,7 @@ Dependencies:
 * libunbound `>=1.4.16` (note: Unbound is not a dependency, libunbound is)
 * libevent `>=2.0`
 * libgtest `>=1.5`
-* Boost `>=1.53 && !=1.54` (note: 1.54 is not supported [more details here](http://goo.gl/RrCFmA)),
+* Boost `>=1.58`
 * BerkeleyDB `>=4.8` (note: on Ubuntu this means installing libdb-dev and libdb++-dev)
 * libunwind (optional, for stack trace on exception)
 * miniupnpc (optional, for NAT punching)
@@ -132,7 +133,7 @@ Dependencies:
 * msys2
 * CMake `>=3.0.0`
 * libunbound `>=1.4.16` (note: Unbound is not a dependency, libunbound is)
-* Boost 1.53 or 1.55 (except 1.54, [more details here](http://goo.gl/RrCFmA))
+* Boost `>=1.58`
 * BerkeleyDB `>=4.8`
 
 **Preparing the Build Environment**

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -957,7 +957,10 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   void core::set_target_blockchain_height(uint64_t target_blockchain_height)
   {
-    m_target_blockchain_height = target_blockchain_height;
+    if (target_blockchain_height > m_target_blockchain_height)
+    {
+      m_target_blockchain_height = target_blockchain_height;
+    }
   }
   //-----------------------------------------------------------------------------------------------
   uint64_t core::get_target_blockchain_height() const

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -263,7 +263,7 @@ namespace cryptonote
     if(context.m_state == cryptonote_connection_context::state_synchronizing)
       return true;
 
-    if(m_core.have_block(hshd.top_id))
+    if(m_core.have_block(hshd.top_id) && !(hshd.current_height < m_core.get_target_blockchain_height()))
     {
       context.m_state = cryptonote_connection_context::state_normal;
       if(is_inital)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -76,6 +76,13 @@ typedef cryptonote::simple_wallet sw;
 
 #define DEFAULT_MIX 4
 
+// workaround for a suspected bug in pthread/kernel on MacOS X
+#ifdef __APPLE__
+#define DEFAULT_MAX_CONCURRENCY 1
+#else
+#define DEFAULT_MAX_CONCURRENCY 0
+#endif
+
 #define LOCK_IDLE_SCOPE() \
   bool auto_refresh_enabled = m_auto_refresh_enabled.load(std::memory_order_relaxed); \
   m_auto_refresh_enabled.store(false, std::memory_order_relaxed); \
@@ -95,7 +102,7 @@ typedef cryptonote::simple_wallet sw;
 namespace
 {
   const command_line::arg_descriptor<std::string> arg_wallet_file = {"wallet-file", sw::tr("Use wallet <arg>"), ""};
-  const command_line::arg_descriptor<std::string> arg_generate_new_wallet = {"generate-new-wallet", sw::tr("Generate new wallet and save it to <arg> or <address>.wallet by default"), ""};
+  const command_line::arg_descriptor<std::string> arg_generate_new_wallet = {"generate-new-wallet", sw::tr("Generate new wallet and save it to <arg>"), ""};
   const command_line::arg_descriptor<std::string> arg_generate_from_view_key = {"generate-from-view-key", sw::tr("Generate incoming-only wallet from view key"), ""};
   const command_line::arg_descriptor<std::string> arg_generate_from_keys = {"generate-from-keys", sw::tr("Generate wallet from private keys"), ""};
   const command_line::arg_descriptor<std::string> arg_generate_from_json = {"generate-from-json", sw::tr("Generate wallet from JSON format file"), ""};
@@ -108,7 +115,7 @@ namespace
   const command_line::arg_descriptor<bool> arg_non_deterministic = {"non-deterministic", sw::tr("Create non-deterministic view and spend keys"), false};
   const command_line::arg_descriptor<int> arg_daemon_port = {"daemon-port", sw::tr("Use daemon instance at port <arg> instead of 18081"), 0};
   const command_line::arg_descriptor<uint32_t> arg_log_level = {"log-level", "", LOG_LEVEL_0};
-  const command_line::arg_descriptor<uint32_t> arg_max_concurrency = {"max-concurrency", "Max number of threads to use for a parallel job", 0};
+  const command_line::arg_descriptor<uint32_t> arg_max_concurrency = {"max-concurrency", "Max number of threads to use for a parallel job", DEFAULT_MAX_CONCURRENCY};
   const command_line::arg_descriptor<std::string> arg_log_file = {"log-file", sw::tr("Specify log file"), ""};
   const command_line::arg_descriptor<bool> arg_testnet = {"testnet", sw::tr("For testnet. Daemon must also be launched with --testnet flag"), false};
   const command_line::arg_descriptor<bool> arg_restricted = {"restricted-rpc", sw::tr("Restricts RPC to view-only commands"), false};

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -129,7 +129,7 @@ string Wallet::displayAmount(uint64_t amount)
 
 uint64_t Wallet::amountFromString(const string &amount)
 {
-    uint64_t result;
+    uint64_t result = 0;
     cryptonote::parse_amount(result, amount);
     return result;
 }
@@ -152,6 +152,11 @@ bool Wallet::paymentIdValid(const string &paiment_id)
 {
     crypto::hash8 pid;
     return tools::wallet2::parse_short_payment_id(paiment_id, pid);
+}
+
+uint64_t Wallet::maximumAllowedAmount()
+{
+    return std::numeric_limits<uint64_t>::max();
 }
 
 
@@ -267,16 +272,18 @@ bool WalletImpl::recover(const std::string &path, const std::string &seed)
 
 bool WalletImpl::close()
 {
-    clearStatus();
+
     bool result = false;
     try {
-        // LOG_PRINT_L0("Calling wallet::store...");
-        m_wallet->store();
+        // do not store wallet with invalid status
+        if (status() == Status_Ok)
+            m_wallet->store();
         // LOG_PRINT_L0("wallet::store done");
         // LOG_PRINT_L0("Calling wallet::stop...");
         m_wallet->stop();
         // LOG_PRINT_L0("wallet::stop done");
         result = true;
+        clearStatus();
     } catch (const std::exception &e) {
         m_status = Status_Error;
         m_errorString = e.what();

--- a/src/wallet/wallet2_api.h
+++ b/src/wallet/wallet2_api.h
@@ -216,6 +216,7 @@ struct Wallet
     static uint64_t amountFromDouble(double amount);
     static std::string genPaymentId();
     static bool paymentIdValid(const std::string &paiment_id);
+    static uint64_t maximumAllowedAmount();
 
     /**
      * @brief refresh - refreshes the wallet, updating transactions from daemon


### PR DESCRIPTION
Adds 64-bit ARMv8 handling to CMakeLists.txt and implements GCC flags for two errata on the Cortex-A53 present on every chip in revision 0:

https://developer.arm.com/docs/epm048406/latest/arm-processor-cortex-a53-mpcore-product-revision-r0-software-developers-errata-notice

835769 affects 64-bit multiply accumulate

843419 affects internal page addressing