### PR TITLE
cmake: fix typo in handling of STACK_TRACE

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,7 +50,7 @@ endfunction ()
 function (enable_stack_trace target)
   if(STACK_TRACE)
     set_property(TARGET ${target}
-      APPEND PROPERTY COMPILER_DEFINITIONS "-DSTACK_TRACE")
+      APPEND PROPERTY COMPILE_DEFINITIONS "STACK_TRACE")
     if (STATIC)
       set_property(TARGET "${target}"
         APPEND PROPERTY LINK_FLAGS "-Wl,--wrap=__cxa_throw")


### PR DESCRIPTION
This fixes the log output not getting redirected to log file.