### PR TITLE
libwallet_api: do not store wallet on close if status is not ok

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -267,16 +267,18 @@ bool WalletImpl::recover(const std::string &path, const std::string &seed)
 
 bool WalletImpl::close()
 {
-    clearStatus();
+
     bool result = false;
     try {
-        // LOG_PRINT_L0("Calling wallet::store...");
-        m_wallet->store();
+        // do not store wallet with invalid status
+        if (status() == Status_Ok)
+            m_wallet->store();
         // LOG_PRINT_L0("wallet::store done");
         // LOG_PRINT_L0("Calling wallet::stop...");
         m_wallet->stop();
         // LOG_PRINT_L0("wallet::stop done");
         result = true;
+        clearStatus();
     } catch (const std::exception &e) {
         m_status = Status_Error;
         m_errorString = e.what();

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -129,7 +129,7 @@ string Wallet::displayAmount(uint64_t amount)
 
 uint64_t Wallet::amountFromString(const string &amount)
 {
-    uint64_t result;
+    uint64_t result = 0;
     cryptonote::parse_amount(result, amount);
     return result;
 }

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -154,6 +154,11 @@ bool Wallet::paymentIdValid(const string &paiment_id)
     return tools::wallet2::parse_short_payment_id(paiment_id, pid);
 }
 
+uint64_t Wallet::maximumAllowedAmount()
+{
+    return std::numeric_limits<uint64_t>::max();
+}
+
 
 ///////////////////////// WalletImpl implementation ////////////////////////
 WalletImpl::WalletImpl(bool testnet)

--- a/src/wallet/wallet2_api.h
+++ b/src/wallet/wallet2_api.h
@@ -216,6 +216,7 @@ struct Wallet
     static uint64_t amountFromDouble(double amount);
     static std::string genPaymentId();
     static bool paymentIdValid(const std::string &paiment_id);
+    static uint64_t maximumAllowedAmount();
 
     /**
      * @brief refresh - refreshes the wallet, updating transactions from daemon

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -217,11 +217,11 @@ void open_wallet(Bitmonero::WalletManager *wmgr, Bitmonero::Wallet **wallet, con
 {
     if (mutex)
         mutex->lock();
-    LOG_PRINT_L3("opening wallet with password '" << pass << "'  in thread: " << std::this_thread::get_id());
+    LOG_PRINT_L3("opening wallet in thread: " << std::this_thread::get_id());
     *wallet = wmgr->openWallet(WALLET_NAME, pass, true);
     LOG_PRINT_L3("wallet address: " << (*wallet)->address());
     LOG_PRINT_L3("wallet status: " << (*wallet)->status());
-    LOG_PRINT_L3("closing wallet with password '" << pass << "'  in thread: " << std::this_thread::get_id());
+    LOG_PRINT_L3("closing wallet in thread: " << std::this_thread::get_id());
     if (mutex)
         mutex->unlock();
 }

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -142,7 +142,7 @@ struct WalletManagerTest : public testing::Test
     {
         std::cout << __FUNCTION__ << std::endl;
         wmgr = Bitmonero::WalletManagerFactory::getWalletManager();
-        Bitmonero::WalletManagerFactory::setLogLevel(Bitmonero::WalletManagerFactory::LogLevel_4);
+        // Bitmonero::WalletManagerFactory::setLogLevel(Bitmonero::WalletManagerFactory::LogLevel_4);
         Utils::deleteWallet(WALLET_NAME);
         Utils::deleteDir(boost::filesystem::path(WALLET_NAME_WITH_DIR).parent_path().string());
     }
@@ -233,7 +233,7 @@ TEST_F(WalletManagerTest, WalletAmountFromString)
 
 }
 
-void open_wallet(Bitmonero::WalletManager *wmgr, Bitmonero::Wallet **wallet, const std::string &pass, std::mutex *mutex)
+void open_wallet_helper(Bitmonero::WalletManager *wmgr, Bitmonero::Wallet **wallet, const std::string &pass, std::mutex *mutex)
 {
     if (mutex)
         mutex->lock();
@@ -288,11 +288,13 @@ TEST_F(WalletManagerTest, WalletManagerOpensWalletWithPasswordAndReopen)
     Bitmonero::Wallet *wallet3 = nullptr;
     std::mutex mutex;
 
-    open_wallet(wmgr, &wallet2, wrong_wallet_pass, nullptr);
+    open_wallet_helper(wmgr, &wallet2, wrong_wallet_pass, nullptr);
+    ASSERT_TRUE(wallet2 != nullptr);
     ASSERT_TRUE(wallet2->status() != Bitmonero::Wallet::Status_Ok);
     ASSERT_TRUE(wmgr->closeWallet(wallet2));
 
-    open_wallet(wmgr, &wallet3, wallet_pass, nullptr);
+    open_wallet_helper(wmgr, &wallet3, wallet_pass, nullptr);
+    ASSERT_TRUE(wallet3 != nullptr);
     ASSERT_TRUE(wallet3->status() == Bitmonero::Wallet::Status_Ok);
     ASSERT_TRUE(wmgr->closeWallet(wallet3));
 }

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -213,6 +213,26 @@ TEST_F(WalletManagerTest, WalletManagerOpensWallet)
 }
 
 
+TEST_F(WalletManagerTest, WalletMaxAmountAsString)
+{
+    LOG_PRINT_L3("max amount: " << Bitmonero::Wallet::displayAmount(
+                     Bitmonero::Wallet::maximumAllowedAmount()));
+
+}
+
+TEST_F(WalletManagerTest, WalletAmountFromString)
+{
+    uint64_t amount = Bitmonero::Wallet::amountFromString("18446740");
+    ASSERT_TRUE(amount > 0);
+    amount = Bitmonero::Wallet::amountFromString("11000000000000");
+    ASSERT_FALSE(amount > 0);
+    amount = Bitmonero::Wallet::amountFromString("0.0");
+    ASSERT_FALSE(amount > 0);
+    amount = Bitmonero::Wallet::amountFromString("10.1");
+    ASSERT_TRUE(amount > 0);
+
+}
+
 void open_wallet(Bitmonero::WalletManager *wmgr, Bitmonero::Wallet **wallet, const std::string &pass, std::mutex *mutex)
 {
     if (mutex)
@@ -225,6 +245,9 @@ void open_wallet(Bitmonero::WalletManager *wmgr, Bitmonero::Wallet **wallet, con
     if (mutex)
         mutex->unlock();
 }
+
+
+
 
 //TEST_F(WalletManagerTest, WalletManagerOpensWalletWithPasswordAndReopenMultiThreaded)
 //{


### PR DESCRIPTION
this fixes following issue: first monero-core tries to open wallet with the empty password;  next, if status is not ok it assumes wallet is password protected, closes currently opened wallet and re-opens it asking password.
 ```wallet2::store()``` called unconditionally on close - and if wallet wasn't actually opened due wrong password - ```wallet2::store()``` corrupts the wallet so it can't be opened anymore.