### PR TITLE
Docs: re-introduce Boost 1.58 min req from 2a2b655

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Dependencies:
 * libunbound `>=1.4.16` (note: Unbound is not a dependency, libunbound is)
 * libevent `>=2.0`
 * libgtest `>=1.5`
-* Boost `>=1.53 && !=1.54` (note: 1.54 is not supported [more details here](http://goo.gl/RrCFmA)),
+* Boost `>=1.58`
 * BerkeleyDB `>=4.8` (note: on Ubuntu this means installing libdb-dev and libdb++-dev)
 * libunwind (optional, for stack trace on exception)
 * miniupnpc (optional, for NAT punching)


### PR DESCRIPTION
CMake will fail if Boost < 1.58. I think we should either adjust the recipe to apply only for clang or keep as-is and enforce 1.58 minimum.

I was hoping for more dialogue in #964 or #956 before merging but here we are.