### PR TITLE
README.md: Boost version for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Dependencies:
 * msys2
 * CMake `>=3.0.0`
 * libunbound `>=1.4.16` (note: Unbound is not a dependency, libunbound is)
-* Boost 1.53 or 1.55 (except 1.54, [more details here](http://goo.gl/RrCFmA))
+* Boost `>=1.58`
 * BerkeleyDB `>=4.8`
 
 **Preparing the Build Environment**


### PR DESCRIPTION
It seems that the changes to the readme from #964 got lost because of conflicts. #981 fixed this for the linux section. But windows is affected too.