### PR TITLE
contrib: example systemd service and config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,15 +215,22 @@ foreground:
 
     ./bin/bitmonerod
 
-To run in background:
-
-    ./bin/bitmonerod --log-file bitmonerod.log --detach
-
 To list all available options, run `./bin/bitmonerod --help`.  Options can be
 specified either on the command line or in a configuration file passed by the
 `--config-file` argument.  To specify an option in the configuration file, add
 a line with the syntax `argumentname=value`, where `argumentname` is the name
 of the argument without the leading dashes, for example `log-level=1`.
+
+To run in background:
+
+    ./bin/bitmonerod --log-file bitmonerod.log --detach
+
+To run as a systemd service, copy
+[bitmonerod.service](utils/systemd/bitmonerod.service) to `/etc/systemd/system/` and
+[bitmonerod.conf](utils/conf/bitmonerod.conf) to `/etc/`. The [example
+service](utils/systemd/bitmonerod.service) assumes that the user `bitmonero` exists
+and its home is the data directory specified in the [example
+config](utils/conf/bitmonerod.conf).
 
 ## Internationalization
 

--- a/utils/conf/bitmonerod.conf
+++ b/utils/conf/bitmonerod.conf
@@ -1,0 +1,7 @@
+# Configuration for bitmonerod
+# Syntax: any command line option may be specified as 'clioptionname=value'.
+# See 'bitmonerod --help' for all available options.
+
+data-dir=/var/lib/bitmonero
+log-file=/var/log/bitmonero/bitmonero.log
+log-level=0

--- a/utils/systemd/bitmonerod.service
+++ b/utils/systemd/bitmonerod.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Monero cryptocurrency node
+After=network.target
+
+[Service]
+User=bitmonero
+Group=bitmonero
+WorkingDirectory=~
+
+Type=forking
+ExecStart=/usr/bin/bitmonerod --config-file /etc/bitmonerod.conf --detach
+
+# This is necessary because bitmonerod does not yet support
+# writing a PID file, which means systemd tries to guess the PID
+# by default, but it guesses wrong (sometimes, depending on
+# random timing of events), because the daemon forks twice.
+# The ultimate fix is for the daemon to write a PID file, and
+# a workaround is to disable the guessing feature in systemd.
+GuessMainPID=no
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Including in light of #977 

This more the job for packages, but including these samples for the benefit of users who want to setup things manually, before packages arrive.

EDIT: If `contrib/` is a bad place for this, then maybe add a subdir called `conf`?