### PR TITLE
Build: move Travis IRC notification channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ notifications:
     on_success: change
     on_failure: change
     channels:
-      - "chat.freenode.net#monero-dev"
+      - "chat.freenode.net#monero-bots"
     nick: monero
     template:
       - "%{result} | %{repository}#%{build_number} (%{commit} : %{author}) | Build details : %{build_url}"


### PR DESCRIPTION
This will allow people to have Travis push notifications
for their repo without spamming the dev channel