### PR TITLE
Add ARMv8 support to CMakeLists and Makefile - 2nd go

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,11 @@ if (ARM_TEST STREQUAL "arm")
   endif()
 endif()
 
+if (ARCH_ID STREQUAL "aarch64")
+  set(ARM 1)
+  set(ARM8 1)
+endif()
+
 if(WIN32 OR ARM)
   set(OPT_FLAGS_RELEASE "-O2")
 else()
@@ -367,23 +372,89 @@ else()
     message(STATUS "AES support enabled")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -maes")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -maes")
-  elseif(ARM)
+  elseif(ARM) #NB ARMv8 DOES support AES, but not yet coded
     message(STATUS "AES support disabled (not available on ARM)")
   else()
     message(STATUS "AES support disabled")
   endif()
 
-  if(ARM6)
-    message(STATUS "Setting ARM6 C and C++ flags")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpu=vfp -mfloat-abi=hard")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=vfp -mfloat-abi=hard")
-  endif()
+  if(ARM)
+    message(STATUS "Setting FPU Flags for ARM Processors")
+    include(TestCXXAcceptsFlag)
 
-  if(ARM7)
-    message(STATUS "Setting ARM7 C and C++ flags")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfloat-abi=hard")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfloat-abi=hard")
-  endif()
+    #NB NEON hardware does not fully implement the IEEE 754 standard for floating-point arithmetic
+    #Need custom assembly code to take full advantage of NEON SIMD
+
+    #Cortex-A5/9  -mfpu=neon-fp16
+    #Cortex-A7/15 -mfpu=neon-vfpv4
+    #Cortex-A8    -mfpu=neon
+    #ARMv8  	  -FP and SIMD on by default for all ARM8v-a series, NO -mfpu setting needed
+
+    #For custom -mtune, processor IDs for ARMv8-A series:
+    #0xd04 - Cortex-A35
+    #0xd07 - Cortex-A57
+    #0xd08 - Cortex-A72
+    #0xd03 - Cortex-A73
+
+    if(NOT ARM8)
+      CHECK_CXX_ACCEPTS_FLAG(-mfpu=vfp3-d16 CXX_ACCEPTS_VFP3_D16)
+      CHECK_CXX_ACCEPTS_FLAG(-mfpu=vfp4 CXX_ACCEPTS_VFP4)
+      CHECK_CXX_ACCEPTS_FLAG(-mfloat-abi=hard CXX_ACCEPTS_MFLOAT_HARD)
+      CHECK_CXX_ACCEPTS_FLAG(-mfloat-abi=softfp CXX_ACCEPTS_MFLOAT_SOFTFP)
+    endif()
+
+    if(ARM8)
+      CHECK_CXX_ACCEPTS_FLAG(-mfix-cortex-a53-835769 CXX_ACCEPTS_MFIX_CORTEX_A53_835769)
+      CHECK_CXX_ACCEPTS_FLAG(-mfix-cortex-a53-843419 CXX_ACCEPTS_MFIX_CORTEX_A53_843419)
+    endif()
+
+    if(ARM6)
+      message(STATUS "Selecting VFP for ARMv6")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpu=vfp")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=vfp")
+    endif(ARM6)
+
+    if(ARM7)
+      if(CXX_ACCEPTS_VFP3_D16 AND NOT CXX_ACCEPTS_VFP4)
+        message(STATUS "Selecting VFP3 for ARMv7")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpu=vfp3-d16")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=vfp3-d16")
+      endif()
+
+      if(CXX_ACCEPTS_VFP4)
+        message(STATUS "Selecting VFP4 for ARMv7")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpu=vfp4")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=vfp4")
+      endif()
+
+      if(CXX_ACCEPTS_MFLOAT_HARD)
+        message(STATUS "Setting Hardware ABI for Floating Point")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfloat-abi=hard")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfloat-abi=hard")
+      endif()
+
+      if(CXX_ACCEPTS_MFLOAT_SOFTFP AND NOT CXX_ACCEPTS_MFLOAT_HARD)
+        message(STATUS "Setting Software ABI for Floating Point")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfloat-abi=softfp")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfloat-abi=softfp")
+      endif()
+    endif(ARM7)
+
+    if(ARM8)
+      if(CXX_ACCEPTS_MFIX_CORTEX_A53_835769)
+        message(STATUS "Enabling Cortex-A53 workaround 835769")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfix-cortex-a53-835769")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfix-cortex-a53-835769")
+      endif()
+
+      if(CXX_ACCEPTS_MFIX_CORTEX_A53_843419)
+        message(STATUS "Enabling Cortex-A53 workaround 843419")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfix-cortex-a53-843419")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfix-cortex-a53-843419")
+      endif()
+    endif(ARM8)
+
+  endif(ARM)
 
   if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_HAS_TR1_TUPLE=0")

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,21 @@
 # Copyright (c) 2014-2016, The Monero Project
-# 
+#
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without modification, are
 # permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice, this list of
 #    conditions and the following disclaimer.
-# 
+#
 # 2. Redistributions in binary form must reproduce the above copyright notice, this list
 #    of conditions and the following disclaimer in the documentation and/or other
 #    materials provided with the distribution.
-# 
+#
 # 3. Neither the name of the copyright holder nor the names of its contributors may be
 #    used to endorse or promote products derived from this software without specific
 #    prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -65,7 +65,11 @@ release-static-arm6:
 release-static-arm7:
 	mkdir -p build/release
 	cd build/release && cmake -D BUILD_TESTS=OFF -D ARCH="armv7-a" -D STATIC=ON -D BUILD_64=OFF -D CMAKE_BUILD_TYPE=release ../.. && $(MAKE)
-	
+
+release-static-armv8:
+	mkdir -p build/release
+	cd build/release && cmake -D BUILD_TESTS=OFF -D ARCH="armv8-a" -D STATIC=ON -D BUILD_64=ON -D CMAKE_BUILD_TYPE=release ../.. && $(MAKE)
+
 release-static: release-static-64
 
 release-static-64:

--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ By default, in either dynamically or statically linked builds, binaries target t
 
 * ```make release-static-64``` builds binaries on Linux on x86_64 portable across POSIX systems on x86_64 processors
 * ```make release-static-32``` builds binaries on Linux on x86_64 or i686 portable across POSIX systems on i686 processors
-* ```make release-static-arm7``` builds binaries on Linux on armv7 portable across POSIX systesm on armv7 processors
+* ```make release-static-arm8``` builds binaries on Linux on armv8 portable across POSIX systems on armv8 processors
+* ```make release-static-arm7``` builds binaries on Linux on armv7 portable across POSIX systems on armv7 processors
 * ```make release-static-arm6``` builds binaries on Linux on armv7 or armv6 portable across POSIX systems on armv6 processors, such as the Raspberry Pi
 * ```make release-static-win64``` builds binaries on 64-bit Windows portable across 64-bit Windows systems
 * ```make release-static-win32``` builds binaries on 64-bit or 32-bit Windows portable across 32-bit Windows systems


### PR DESCRIPTION
After @radfish's changes, I've rewritten the CMakeLists.txt, Makefile and README.md to add support for ARMv8 compilation.

Also added flags for workarounds of issues on the Cortex-A53 that affect 64-bit MAC operations and internal paging 

CMakeLists should also try to select the most appropriate flags for the FPU and floating-point ABI for ARMv7 devices

NB ARMv8 has the FPU and NEON SIMD 'always on' which is why -mfpu and -mfloat options cease compilation