### PR TITLE
wallet_rpc_server: return payment id in make_integrated_address RPC

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -473,6 +473,7 @@ namespace tools
       }
 
       res.integrated_address = m_wallet.get_account().get_public_integrated_address_str(payment_id, m_wallet.testnet());
+      res.payment_id = epee::string_tools::pod_to_hex(payment_id);
       return true;
     }
     catch (std::exception &e)

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -414,9 +414,11 @@ namespace wallet_rpc
     struct response
     {
       std::string integrated_address;
+      std::string payment_id;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(integrated_address)
+        KV_SERIALIZE(payment_id)
       END_KV_SERIALIZE_MAP()
     };
   };


### PR DESCRIPTION
It is useful, especially when requesting a random one