### PR TITLE
cmake: tests fix build with system gtest

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Packaging for your favorite distribution would be a welcome contribution!
 * pkg-config
 * libunbound `>=1.4.16` (note: Unbound is not a dependency, libunbound is)
 * libevent `>=2.0`
-* libgtest `>=1.5`
 * Boost `>=1.58`
 * BerkeleyDB `>=4.8` (note: on Ubuntu this means installing libdb-dev and libdb++-dev)
 * libunwind (optional, for stack trace on exception)
@@ -87,6 +86,7 @@ Packaging for your favorite distribution would be a welcome contribution!
 * ldns `>=1.6.17` (optional, for statically-linked binaries)
 * expat `>=1.1` (optional, for statically-linked binaries)
 * bison or yacc (optional, for statically-linked binaries)
+* GTest `>=1.5` (optional, for running test suite) (NOTE: `libgtest-dev` package in Ubuntu ships without binaries and requires a manual build; `gtest` on Arch includes binaries)
 * Doxygen (optional, for generating documentation)
 * graphviz (optional, for generating documentation)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,21 +42,22 @@ find_package(GTest)
 if (GTest_FOUND)
   include_directories(SYSTEM ${GTEST_INCLUDE_DIRS})
 else ()
+  message(STATUS "GTest not found on the system: will use GTest bundled with this source")
   add_subdirectory(gtest)
   include_directories(SYSTEM "${gtest_SOURCE_DIR}/include" "${gtest_SOURCE_DIR}")
 
   # Emulate the FindGTest module's variable.
-  set(GTEST_MAIN_LIBRARIES gtest_main)
+  set(GTEST_LIBRARIES gtest)
 
   # Ignore some warnings when building gtest binaries.
   if(NOT MSVC)
-    set_property(TARGET gtest gtest_main
+    set_property(TARGET gtest
       APPEND_STRING
       PROPERTY
         COMPILE_FLAGS " -Wno-undef -Wno-sign-compare")
   endif()
 
-  set_property(TARGET gtest gtest_main
+  set_property(TARGET gtest
       PROPERTY
         FOLDER "${folder}")
 endif ()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,9 @@
 # 
 # Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
+# The docs say this only affects grouping in IDEs
+set(folder "tests")
+
 if (WIN32 AND STATIC)
   add_definitions(-DSTATICLIB)
   # miniupnp changed their static define
@@ -52,6 +55,10 @@ else ()
       PROPERTY
         COMPILE_FLAGS " -Wno-undef -Wno-sign-compare")
   endif()
+
+  set_property(TARGET gtest gtest_main
+      PROPERTY
+        FOLDER "${folder}")
 endif ()
 
 if (NOT DEFINED ENV{TRAVIS})
@@ -84,7 +91,7 @@ target_link_libraries(hash-target-tests
     cryptonote_core)
 set_property(TARGET hash-target-tests
   PROPERTY
-    FOLDER "tests")
+    FOLDER "${folder}")
 
 add_test(
   NAME    hash-target
@@ -97,4 +104,4 @@ else ()
   add_custom_target(tests DEPENDS coretests difficulty hash performance_tests core_proxy unit_tests)
 endif ()
 
-set_property(TARGET gtest gtest_main hash-target-tests tests PROPERTY FOLDER "tests")
+set_property(TARGET tests PROPERTY FOLDER "${folder}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,11 +97,17 @@ add_test(
   NAME    hash-target
   COMMAND hash-target-tests)
 
-# Skip the core_tests if we are running in Travis-CI because they will take too long
-if (DEFINED ENV{TRAVIS})
-  add_custom_target(tests DEPENDS difficulty hash performance_tests core_proxy unit_tests)
-else ()
-  add_custom_target(tests DEPENDS coretests difficulty hash performance_tests core_proxy unit_tests)
-endif ()
+set(enabled_tests
+    difficulty
+    hash
+    performance_tests
+    core_proxy
+    unit_tests)
 
+# Skip the core_tests in Travis-CI because they will take too long
+if (NOT DEFINED ENV{TRAVIS})
+    list(APPEND enabled_tests coretests)
+endif()
+
+add_custom_target(tests DEPENDS enabled_tests)
 set_property(TARGET tests PROPERTY FOLDER "${folder}")

--- a/tests/daemon_tests/CMakeLists.txt
+++ b/tests/daemon_tests/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(transfers
     crypto
     common
     epee
-    ${GTEST_MAIN_LIBRARIES}
+    ${GTEST_LIBRARIES}
     ${Boost_LIBRARIES})
 
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_transfers")

--- a/tests/libwallet_api_tests/CMakeLists.txt
+++ b/tests/libwallet_api_tests/CMakeLists.txt
@@ -40,7 +40,7 @@ add_executable(libwallet_api_tests
 target_link_libraries(libwallet_api_tests
   LINK_PRIVATE
     wallet
-    ${GTEST_MAIN_LIBRARIES}
+    ${GTEST_LIBRARIES}
     ${EXTRA_LIBRARIES})
 
 set_property(TARGET libwallet_api_tests

--- a/tests/net_load_tests/CMakeLists.txt
+++ b/tests/net_load_tests/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(net_load_tests_clt
 	otshell_utils
 	p2p
 	cryptonote_core
-    ${GTEST_MAIN_LIBRARIES}
+    ${GTEST_LIBRARIES}
     ${Boost_CHRONO_LIBRARY}
     ${Boost_DATE_TIME_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}
@@ -62,7 +62,7 @@ target_link_libraries(net_load_tests_srv
 	otshell_utils
 	p2p
 	cryptonote_core
-    ${GTEST_MAIN_LIBRARIES}
+    ${GTEST_LIBRARIES}
     ${Boost_CHRONO_LIBRARY}
     ${Boost_DATE_TIME_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -69,7 +69,7 @@ target_link_libraries(unit_tests
     rpc
     wallet
     p2p
-    ${GTEST_MAIN_LIBRARIES}
+    ${GTEST_LIBRARIES}
     ${Boost_CHRONO_LIBRARY}
     ${Boost_REGEX_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}


### PR DESCRIPTION
The build with the system gtest broke because it was linking against -lgtest_main instead of -lgtest (or both). Additional problem was a bug  in the cmake script.

Issues #980 #983