### PR TITLE
Remove blocks_per_sync limits

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3378,7 +3378,7 @@ bool Blockchain::cleanup_handle_incoming_blocks(bool force_sync)
         store_blockchain();
       m_sync_counter = 0;
     }
-    else if (m_sync_counter >= m_db_blocks_per_sync)
+    else if (m_db_blocks_per_sync && m_sync_counter >= m_db_blocks_per_sync)
     {
       if(m_db_sync_mode == db_async)
       {

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -372,11 +372,10 @@ namespace cryptonote
 
       if(options.size() >= 3 && !safemode)
       {
-        blocks_per_sync = atoll(options[2].c_str());
-        if(blocks_per_sync > 5000)
-          blocks_per_sync = 5000;
-        if(blocks_per_sync == 0)
-          blocks_per_sync = 1;
+        char *endptr;
+        uint64_t bps = strtoull(options[2].c_str(), &endptr, 0);
+        if (*endptr == '\0')
+          blocks_per_sync = bps;
       }
 
       bool auto_remove_logs = command_line::get_arg(vm, command_line::arg_db_auto_remove_logs) != 0;


### PR DESCRIPTION
The code used to cap at 5000 blocks per sync. It also treated 0 as 1.
Remove these checks; if specified as 0 do no periodic syncs at all.
Then the user is responsible for syncing in some external process.